### PR TITLE
Restoring extra PIP for clarity

### DIFF
--- a/src/health/azure/examples/environment.yml
+++ b/src/health/azure/examples/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - pip:
     - azureml-sdk==1.23.0
     - conda-merge==0.1.5
+  - pip:
     - --index-url https://test.pypi.org/simple/
     - --extra-index-url https://pypi.org/simple
     - hi-ml


### PR DESCRIPTION
Helps to delimit where the reordering of the PIP indexes applies.

Closes Issue #71