### PR TITLE
Remove random post number from PyPi publication process

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,36 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,36 +1,39 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Upload Python Package
 
 on:
   release:
     types: [published]
 
+env:
+  pythonVersion: 3.7
+  PYPI_API_TOKEN: ${{ secrets.HIML_TENANT_ID }}
+
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python
+      with:
+        lfs: true
+
+    - name: Set up Python ${{ env.pythonVersion }}
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
+        python-version: ${{ env.pythonVersion }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r run_requirements.txt
+          pip install -r test_requirements.txt
+
     - name: Build package
-      run: python -m build
+      run: |
+        make clean
+        make build
+  
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: PYPI_API_TOKEN


### PR DESCRIPTION
Closes #75 

Add GitHub action to publish the package to PyPi. As it is running in GitHub this should use the incrementing GitHub run number as the post number, not our 9 digit random string. This is important so that newer releases are seen as more recent through their nameing. Note though, as @JonathanTripp points out in a comment in `setup.py` that this is frowned on:

> The use of post-releases to publish maintenance releases containing actual bug fixes is strongly discouraged.  
> In general, it is better to use a longer release number and increment the final component for each 
> maintenance release.

(from [here](https://www.python.org/dev/peps/pep-0440/#post-releases))