### PR TITLE
adding v to GITHUB_REF_TAG_COMMIT

### DIFF
--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -175,7 +175,7 @@ jobs:
   publish-testpypi-pkg:
     runs-on: ubuntu-latest
     needs: [test-artifact-pkg]
-    if: "!startsWith(github.ref, 'refs/tags')"
+    if: "!startsWith(github.ref, 'refs/tags/v')"
     steps:
       - name: Download Distribution
         uses: actions/download-artifact@v2
@@ -353,7 +353,7 @@ jobs:
   publish-pypi-pkg:
     runs-on: ubuntu-latest
     needs: [test-artifact-pkg]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download Distribution
         uses: actions/download-artifact@v2

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ version = ''
 # See also:
 # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 # https://github.com/pypa/gh-action-pypi-publish
-GITHUB_REF_TAG_COMMIT = 'refs/tags/'
+GITHUB_REF_TAG_COMMIT = 'refs/tags/v'
 
 github_ref = os.getenv('GITHUB_REF')
 if github_ref and github_ref.startswith(GITHUB_REF_TAG_COMMIT):


### PR DESCRIPTION
Closes #79 

Our code in `setup.py` will trigger with new tags. `setuptools.setup` will reject tags that are not release versions but we could do more to make that explicit by checking for the leading "v".

Also when we tag releases as, say, "v0.1.1" the leading "v" is carried through `setuptools.setup` so it becomes part of the pip test download

> Successfully installed pip-21.2.4
> Collecting hi-ml==v0.1.0
>   Downloading hi_ml-0.1.0-py3-none-any.whl (25 kB)

(from [here](https://github.com/microsoft/hi-ml/runs/3362573497?check_suite_focus=true#step:6:29))

This works, but it would be cleaner to submit the version number using the public version identifier format mandated in [PEP 440](https://www.python.org/dev/peps/pep-0440/#public-version-identifiers), i.e. without the leading "v"

A simple fix is to append "v" to the `GITHUB_REF_TAG_COMMIT` constant

