### PR TITLE
compute_cluster_name should not be required local

### DIFF
--- a/src/health/azure/himl.py
+++ b/src/health/azure/himl.py
@@ -250,7 +250,7 @@ def _str_to_path(s: Optional[PathOrString]) -> Optional[Path]:
 
 def submit_to_azure_if_needed(  # type: ignore
         # ignore missing return statement since we 'exit' instead when submitting to AzureML
-        compute_cluster_name: str,
+        compute_cluster_name: str = "",
         entry_script: Optional[PathOrString] = None,
         aml_workspace: Optional[Workspace] = None,
         workspace_config_path: Optional[PathOrString] = None,
@@ -366,6 +366,7 @@ def submit_to_azure_if_needed(  # type: ignore
             output_folder=Path.cwd() / OUTPUT_FOLDER,
             logs_folder=Path.cwd() / LOGS_FOLDER
         )
+
     if snapshot_root_directory is None:
         logging.info(f"No snapshot root directory given. Uploading all files in the current directory {Path.cwd()}")
         snapshot_root_directory = Path.cwd()


### PR DESCRIPTION
Closes #82 

`submit_to_azure_if_needed` has just one parameter which has no default, `compute_cluster_name`. But some consumers of our package (e.g. InnerEye) may have the option to train a model locally. In that situation we intend them to still call `submit_to_azure_if_needed` (that's why it is called _if_needed_) but for a purely local run why should they have a  `compute_cluster_name`? It should also have a default, `""`.