### PR TITLE
Fix for invalid "." dataset location in AzureML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ the section headers (Added/Changed/...) and incrementing the package version.
 ### Changed
 
 ### Fixed
+- ([#161](https://github.com/microsoft/hi-ml/pull/161)) Empty string as target folder for a dataset creates an invalid mounting path for the dataset in AzureML (fixes #160)
 
 ### Removed
 

--- a/hi-ml-azure/src/health_azure/datasets.py
+++ b/hi-ml-azure/src/health_azure/datasets.py
@@ -109,6 +109,8 @@ class DatasetConfig:
         self.datastore = datastore
         self.version = version
         self.use_mounting = use_mounting
+        if target_folder == ".":
+            raise ValueError("Can't mount or download a dataset to the current working directory.")
         self.target_folder = target_folder
         self.local_folder = Path(local_folder) if local_folder else None
 

--- a/hi-ml-azure/src/health_azure/datasets.py
+++ b/hi-ml-azure/src/health_azure/datasets.py
@@ -95,7 +95,7 @@ class DatasetConfig:
             Defaults: False (downloading) for datasets that are script inputs, True (mounting) for datasets that are
             script outputs.
         :param target_folder: The folder into which the dataset should be downloaded or mounted. If left empty, a
-            random folder on /tmp will be chosen.
+            random folder on /tmp will be chosen. Do NOT use "." as the target_folder.
         :param local_folder: The folder on the local machine at which the dataset is available. This
             is used only for runs outside of AzureML. If this is empty then the target_folder will be used to
             mount or download the dataset.

--- a/hi-ml-azure/src/health_azure/datasets.py
+++ b/hi-ml-azure/src/health_azure/datasets.py
@@ -109,6 +109,7 @@ class DatasetConfig:
         self.datastore = datastore
         self.version = version
         self.use_mounting = use_mounting
+        # If target_folder is "" then convert to None
         self.target_folder = Path(target_folder) if target_folder else None
         if str(self.target_folder) == ".":
             raise ValueError("Can't mount or download a dataset to the current working directory.")
@@ -139,7 +140,7 @@ class DatasetConfig:
         azureml_dataset = get_or_create_dataset(workspace=workspace,
                                                 dataset_name=self.name,
                                                 datastore_name=self.datastore)
-        target_path = self.target_folder if self.target_folder is not None else Path(tempfile.mkdtemp())
+        target_path = self.target_folder or Path(tempfile.mkdtemp())
         use_mounting = self.use_mounting if self.use_mounting is not None else False
         if use_mounting:
             status += "mounted at "
@@ -171,7 +172,8 @@ class DatasetConfig:
                                                 dataset_name=self.name,
                                                 datastore_name=self.datastore)
         named_input = azureml_dataset.as_named_input(_input_dataset_key(index=dataset_index))
-        # Empty strings for target folder should map to None
+        # If running on windows then self.target_folder may be a WindowsPath, make sure it is
+        # in posix format for Azure.
         path_on_compute = self.target_folder.as_posix() if self.target_folder is not None else None
         use_mounting = False if self.use_mounting is None else self.use_mounting
         if use_mounting:

--- a/hi-ml-azure/src/health_azure/datasets.py
+++ b/hi-ml-azure/src/health_azure/datasets.py
@@ -80,7 +80,7 @@ class DatasetConfig:
                  datastore: str = "",
                  version: Optional[int] = None,
                  use_mounting: Optional[bool] = None,
-                 target_folder: Optional[PathOrString] = None,
+                 target_folder: str = "",
                  local_folder: Optional[PathOrString] = None):
         """
         :param name: The name of the dataset, as it was registered in the AzureML workspace. For output datasets,

--- a/hi-ml-azure/src/health_azure/datasets.py
+++ b/hi-ml-azure/src/health_azure/datasets.py
@@ -80,7 +80,7 @@ class DatasetConfig:
                  datastore: str = "",
                  version: Optional[int] = None,
                  use_mounting: Optional[bool] = None,
-                 target_folder: str = "",
+                 target_folder: Optional[PathOrString] = None,
                  local_folder: Optional[PathOrString] = None):
         """
         :param name: The name of the dataset, as it was registered in the AzureML workspace. For output datasets,
@@ -109,9 +109,9 @@ class DatasetConfig:
         self.datastore = datastore
         self.version = version
         self.use_mounting = use_mounting
-        if target_folder == ".":
+        self.target_folder = Path(target_folder) if target_folder else None
+        if str(self.target_folder) == ".":
             raise ValueError("Can't mount or download a dataset to the current working directory.")
-        self.target_folder = target_folder
         self.local_folder = Path(local_folder) if local_folder else None
 
     def to_input_dataset_local(self, workspace: Optional[Workspace]) -> Tuple[Optional[Path], Optional[MountContext]]:
@@ -139,7 +139,7 @@ class DatasetConfig:
         azureml_dataset = get_or_create_dataset(workspace=workspace,
                                                 dataset_name=self.name,
                                                 datastore_name=self.datastore)
-        target_path = Path(self.target_folder) if self.target_folder else Path(tempfile.mkdtemp())
+        target_path = self.target_folder if self.target_folder is not None else Path(tempfile.mkdtemp())
         use_mounting = self.use_mounting if self.use_mounting is not None else False
         if use_mounting:
             status += "mounted at "
@@ -172,7 +172,7 @@ class DatasetConfig:
                                                 datastore_name=self.datastore)
         named_input = azureml_dataset.as_named_input(_input_dataset_key(index=dataset_index))
         # Empty strings for target folder should map to None
-        path_on_compute = self.target_folder or None
+        path_on_compute = self.target_folder.as_posix() if self.target_folder is not None else None
         use_mounting = False if self.use_mounting is None else self.use_mounting
         if use_mounting:
             status += "mounted at "

--- a/hi-ml-azure/testazure/testazure/test_datasets.py
+++ b/hi-ml-azure/testazure/testazure/test_datasets.py
@@ -5,7 +5,9 @@
 """
 Test the data input and output functionality
 """
+from pathlib import Path
 from unittest import mock
+from health_azure.utils import PathOrString
 
 import pytest
 from azureml._restclient.exceptions import ServiceException
@@ -94,9 +96,14 @@ def test_dataset_input_target_empty() -> None:
     assert aml_dataset.path_on_compute is None
 
 
-def test_dataset_invalid_target() -> None:
+@pytest.mark.parametrize("target_folder", [
+    ".",
+    Path(),
+    Path("."),
+])
+def test_dataset_invalid_target(target_folder: PathOrString) -> None:
     with pytest.raises(ValueError) as ex:
-        DatasetConfig(name="hello_world", datastore=DEFAULT_DATASTORE, target_folder=".")
+        DatasetConfig(name="hello_world", datastore=DEFAULT_DATASTORE, target_folder=target_folder)
     assert "current working directory" in str(ex)
 
 

--- a/hi-ml-azure/testazure/testazure/test_datasets.py
+++ b/hi-ml-azure/testazure/testazure/test_datasets.py
@@ -84,13 +84,17 @@ def test_dataset_input() -> None:
     assert aml_dataset.mode == "mount"
 
 
-def test_dataset_input_target_empty() -> None:
+@pytest.mark.parametrize("target_folder", [
+    "",
+    None,
+])
+def test_dataset_input_target_empty(target_folder: PathOrString) -> None:
     """
     Leaving the target folder empty should NOT create a path_on_compute that is "."
     """
     workspace = DEFAULT_WORKSPACE.workspace
     # This dataset must exist in the workspace already, or at least in blob storage.
-    dataset_config = DatasetConfig(name="hello_world", datastore=DEFAULT_DATASTORE, target_folder="")
+    dataset_config = DatasetConfig(name="hello_world", datastore=DEFAULT_DATASTORE, target_folder=target_folder)
     aml_dataset = dataset_config.to_input_dataset(workspace=workspace, dataset_index=1)
     assert isinstance(aml_dataset, DatasetConsumptionConfig)
     assert aml_dataset.path_on_compute is None
@@ -102,6 +106,9 @@ def test_dataset_input_target_empty() -> None:
     Path("."),
 ])
 def test_dataset_invalid_target(target_folder: PathOrString) -> None:
+    """
+    Passing in "." as a target_folder shouold raise an exception.
+    """
     with pytest.raises(ValueError) as ex:
         DatasetConfig(name="hello_world", datastore=DEFAULT_DATASTORE, target_folder=target_folder)
     assert "current working directory" in str(ex)

--- a/hi-ml-azure/testazure/testazure/test_datasets.py
+++ b/hi-ml-azure/testazure/testazure/test_datasets.py
@@ -97,7 +97,7 @@ def test_dataset_input_target_empty() -> None:
 def test_dataset_invalid_target() -> None:
     with pytest.raises(ValueError) as ex:
         DatasetConfig(name="hello_world", datastore=DEFAULT_DATASTORE, target_folder=".")
-    assert "current working directory" in ex
+    assert "current working directory" in str(ex)
 
 
 def test_dataset_output() -> None:

--- a/hi-ml-azure/testazure/testazure/test_datasets.py
+++ b/hi-ml-azure/testazure/testazure/test_datasets.py
@@ -81,6 +81,18 @@ def test_dataset_input() -> None:
     assert aml_dataset.mode == "mount"
 
 
+def test_dataset_input_target_empty() -> None:
+    """
+    Leaving the target folder empty should NOT create a path_on_compute that is "."
+    """
+    workspace = DEFAULT_WORKSPACE.workspace
+    # This dataset must exist in the workspace already, or at least in blob storage.
+    dataset_config = DatasetConfig(name="hello_world", datastore=DEFAULT_DATASTORE, target_folder="")
+    aml_dataset = dataset_config.to_input_dataset(workspace=workspace, dataset_index=1)
+    assert isinstance(aml_dataset, DatasetConsumptionConfig)
+    assert aml_dataset.path_on_compute is None
+
+
 def test_dataset_output() -> None:
     """
     Test turning a dataset setup object to an actual AML output dataset.

--- a/hi-ml-azure/testazure/testazure/test_datasets.py
+++ b/hi-ml-azure/testazure/testazure/test_datasets.py
@@ -6,14 +6,15 @@
 Test the data input and output functionality
 """
 from unittest import mock
-from azureml.exceptions._azureml_exception import UserErrorException
 
 import pytest
+from azureml._restclient.exceptions import ServiceException
 from azureml.core import Dataset
 from azureml.data import FileDataset, OutputFileDatasetConfig
 from azureml.data.azure_storage_datastore import AzureBlobDatastore
 from azureml.data.dataset_consumption_config import DatasetConsumptionConfig
-from azureml._restclient.exceptions import ServiceException
+from azureml.exceptions._azureml_exception import UserErrorException
+
 from health_azure.datasets import (DatasetConfig, _input_dataset_key, _output_dataset_key,
                                    _replace_string_datasets, get_datastore, get_or_create_dataset)
 from testazure.util import DEFAULT_DATASTORE, DEFAULT_WORKSPACE
@@ -91,6 +92,12 @@ def test_dataset_input_target_empty() -> None:
     aml_dataset = dataset_config.to_input_dataset(workspace=workspace, dataset_index=1)
     assert isinstance(aml_dataset, DatasetConsumptionConfig)
     assert aml_dataset.path_on_compute is None
+
+
+def test_dataset_invalid_target() -> None:
+    with pytest.raises(ValueError) as ex:
+        DatasetConfig(name="hello_world", datastore=DEFAULT_DATASTORE, target_folder=".")
+    assert "current working directory" in ex
 
 
 def test_dataset_output() -> None:


### PR DESCRIPTION
Using an empty string as the target_folder in DatasetConfig creates an AML download location that is ".", which makes the job logic choke.

Fixes #160 

Please follow the guidelines for PRs contained [here](docs/source/contributing.md). Checklist:

- [x] Ensure that your PR is small, and implements one change.
- [x] Add unit tests for all functions that you introduced or modified.
- [x] Run PyCharm's code cleanup tools on your Python files.
- [ ] Ensure that documentation renders correctly in Sphinx (run Sphinx via `make html` in the `docs folder)
- [ ] Link the correct GitHub issue for tracking.
- [ ] Update the [Changelog](CHANGELOG.md) file: Describe your change in terms of 
Added/Changed/Removed/... in the "Upcoming" section.
- [ ] When merging your PR, **replace the default merge message** with a brief description of your PR,
and if needed a motivation why that change was required.