### PR TITLE
Fix DeepMIL metrics bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ the environment file since it is necessary for the augmentations.
 ### Fixed
 - ([#188](https://github.com/microsoft/hi-ml/pull/188)) Updated DeepSMILES models. Now they are uptodate with innereye-dl.
 - ([#179](https://github.com/microsoft/hi-ml/pull/179)) HEDJitter was jittering the D channel as well. StainNormalization was relying on skimage.
+- ([#195](https://github.com/microsoft/hi-ml/pull/195)) Fix DeepMIL metrics bug whereby hard labels were used instead of probabilities.
 
 ### Removed
 

--- a/hi-ml-histopathology/src/histopathology/models/deepmil.py
+++ b/hi-ml-histopathology/src/histopathology/models/deepmil.py
@@ -170,12 +170,14 @@ class DeepMILModule(LightningModule):
                                   MetricsKey.ACC_WEIGHTED: Accuracy(num_classes=self.n_classes, average='weighted'),
                                   MetricsKey.CONF_MATRIX: ConfusionMatrix(num_classes=self.n_classes)})
         else:
-            return nn.ModuleDict({MetricsKey.ACC: Accuracy(),
+            threshold = 0.5
+            return nn.ModuleDict({MetricsKey.ACC: Accuracy(threshold=threshold),
                                   MetricsKey.AUROC: AUROC(num_classes=self.n_classes),
-                                  MetricsKey.PRECISION: Precision(),
-                                  MetricsKey.RECALL: Recall(),
-                                  MetricsKey.F1: F1(),
-                                  MetricsKey.CONF_MATRIX: ConfusionMatrix(num_classes=self.n_classes + 1)})
+                                  MetricsKey.PRECISION: Precision(threshold=threshold),
+                                  MetricsKey.RECALL: Recall(threshold=threshold),
+                                  MetricsKey.F1: F1(threshold=threshold),
+                                  MetricsKey.CONF_MATRIX: ConfusionMatrix(num_classes=self.n_classes+1,
+                                                                          threshold=threshold)})
 
     def log_metrics(self,
                     stage: str) -> None:
@@ -229,24 +231,24 @@ class DeepMILModule(LightningModule):
         else:
             loss = self.loss_fn(bag_logits.squeeze(1), bag_labels.float())
 
-        probs = self.activation_fn(bag_logits)
+        predicted_probs = self.activation_fn(bag_logits)
         if self.n_classes > 1:
-            preds = argmax(probs, dim=1)
+            predicted_labels = argmax(predicted_probs, dim=1)
         else:
-            preds = round(probs)
+            predicted_labels = round(predicted_probs)
 
         loss = loss.view(-1, 1)
-        preds = preds.view(-1, 1)
-        probs = probs.view(-1, 1)
+        predicted_labels = predicted_labels.view(-1, 1)
+        predicted_probs = predicted_probs.view(-1, 1)
         bag_labels = bag_labels.view(-1, 1)
 
         results = dict()
         for metric_object in self.get_metrics_dict(stage).values():
-            metric_object.update(preds, bag_labels)
+            metric_object.update(predicted_probs, bag_labels)
         results.update({ResultsKey.SLIDE_ID: batch[TilesDataset.SLIDE_ID_COLUMN],
                         ResultsKey.TILE_ID: batch[TilesDataset.TILE_ID_COLUMN],
                         ResultsKey.IMAGE_PATH: batch[TilesDataset.PATH_COLUMN], ResultsKey.LOSS: loss,
-                        ResultsKey.PROB: probs, ResultsKey.PRED_LABEL: preds,
+                        ResultsKey.PROB: predicted_probs, ResultsKey.PRED_LABEL: predicted_labels,
                         ResultsKey.TRUE_LABEL: bag_labels, ResultsKey.BAG_ATTN: bag_attn_list,
                         ResultsKey.IMAGE: batch[TilesDataset.IMAGE_COLUMN]})
 

--- a/hi-ml-histopathology/src/histopathology/models/deepmil.py
+++ b/hi-ml-histopathology/src/histopathology/models/deepmil.py
@@ -176,8 +176,7 @@ class DeepMILModule(LightningModule):
                                   MetricsKey.PRECISION: Precision(threshold=threshold),
                                   MetricsKey.RECALL: Recall(threshold=threshold),
                                   MetricsKey.F1: F1(threshold=threshold),
-                                  MetricsKey.CONF_MATRIX: ConfusionMatrix(num_classes=self.n_classes+1,
-                                                                          threshold=threshold)})
+                                  MetricsKey.CONF_MATRIX: ConfusionMatrix(num_classes=2, threshold=threshold)})
 
     def log_metrics(self,
                     stage: str) -> None:

--- a/hi-ml-histopathology/testhisto/testhisto/models/test_deepmil.py
+++ b/hi-ml-histopathology/testhisto/testhisto/models/test_deepmil.py
@@ -4,11 +4,13 @@
 #  ------------------------------------------------------------------------------------------
 
 import os
-from typing import Callable, Dict, List, Type  # noqa
+from typing import Any, Callable, Dict, Iterable, List, Type
+from unittest.mock import MagicMock
 
 import pytest
 import torch
 from torch import Tensor, argmax, nn, rand, randint, randn, round, stack, allclose
+from torch.utils.data._utils.collate import default_collate
 from torchvision.models import resnet18
 
 from health_ml.lightning_container import LightningContainer
@@ -20,9 +22,10 @@ from health_ml.networks.layers.attention_layers import (
 from histopathology.configs.classification.DeepSMILECrck import DeepSMILECrck
 from histopathology.configs.classification.DeepSMILEPanda import DeepSMILEPanda
 from histopathology.datamodules.base_module import TilesDataModule
+from histopathology.datasets.base_dataset import TilesDataset
 from histopathology.datasets.default_paths import PANDA_TILES_DATASET_DIR, TCGA_CRCK_DATASET_DIR
 from histopathology.models.deepmil import DeepMILModule
-from histopathology.models.encoders import ImageNetEncoder, TileEncoder
+from histopathology.models.encoders import IdentityEncoder, ImageNetEncoder, TileEncoder
 from histopathology.utils.naming import MetricsKey, ResultsKey
 
 
@@ -108,6 +111,85 @@ def test_lightningmodule(
             score = metric_object(preds.view(-1, 1), bag_labels.view(-1, 1))
             assert torch.all(score >= 0)
             assert torch.all(score <= 1)
+
+
+def test_metrics() -> None:
+    input_dim = (128,)
+    module = DeepMILModule(
+        encoder=IdentityEncoder(input_dim=input_dim),
+        label_column=TilesDataset.LABEL_COLUMN,
+        n_classes=1,
+        pooling_layer=AttentionLayer,
+    )
+
+    # Patching to enable running the module without a Trainer object
+    module.trainer = MagicMock(world_size=1)  # type: ignore
+    module.log = MagicMock()  # type: ignore
+
+    batch_size = 20
+    bag_size = 5
+    class_weights = torch.tensor([.8, .2])
+    bags: List[Dict] = []
+    for slide_idx in range(batch_size):
+        bag_label = torch.multinomial(class_weights, 1)
+        sample: Dict[str, Iterable] = {
+            TilesDataset.SLIDE_ID_COLUMN: [str(slide_idx)] * bag_size,
+            TilesDataset.TILE_ID_COLUMN: [f"{slide_idx}-{tile_idx}"
+                                          for tile_idx in range(bag_size)],
+            TilesDataset.IMAGE_COLUMN: rand(bag_size, *input_dim),
+            TilesDataset.LABEL_COLUMN: bag_label.expand(bag_size),
+        }
+        sample[TilesDataset.PATH_COLUMN] = [tile_id + '.png'
+                                            for tile_id in sample[TilesDataset.TILE_ID_COLUMN]]
+        bags.append(sample)
+    batch = default_collate(bags)
+
+    # Test that the module metrics match manually computed metrics with the correct inputs
+    module_metrics_dict = module.test_metrics
+    independent_metrics_dict = module.get_metrics()
+
+    results = module.test_step(batch, 0)
+    predicted_probs = results[ResultsKey.PROB]
+    true_labels = results[ResultsKey.TRUE_LABEL]
+
+    for key, metric_obj in module_metrics_dict.items():
+        value = metric_obj.compute()
+        expected_value = independent_metrics_dict[key](predicted_probs, true_labels)
+        assert torch.allclose(value, expected_value), f"Discrepancy in '{key}' metric"
+
+    # TODO: Intercept calls to Metric.update() and check input dtype and num unique
+
+    # Test that thresholded metrics (e.g. accuracy, precision, etc.) change
+    # as the threshold is varied. If they don't, it's a sign that the inputs
+    # are hard labels instead of continuous scores.
+    thresholded_metrics_keys = [key for key, metric in module_metrics_dict.items()
+                                if hasattr(metric, 'threshold')]
+
+    def set_metrics_threshold(metrics_dict: Any, threshold: float) -> None:
+        for key in thresholded_metrics_keys:
+            metrics_dict[key].threshold = threshold
+
+    def reset_metrics(metrics_dict: Any) -> None:
+        for metric_obj in metrics_dict.values():
+            metric_obj.reset()
+
+    low_threshold, high_threshold = torch.quantile(predicted_probs, torch.tensor([0.1, 0.9]))
+
+    reset_metrics(module_metrics_dict)
+    set_metrics_threshold(module_metrics_dict, threshold=low_threshold)
+    _ = module.test_step(batch, 0)
+    results_low_threshold = {key: module_metrics_dict[key].compute()
+                             for key in thresholded_metrics_keys}
+
+    reset_metrics(module_metrics_dict)
+    set_metrics_threshold(module_metrics_dict, threshold=high_threshold)
+    _ = module.test_step(batch, 0)
+    results_high_threshold = {key: module_metrics_dict[key].compute()
+                              for key in thresholded_metrics_keys}
+
+    for key in thresholded_metrics_keys:
+        assert not torch.allclose(results_low_threshold[key], results_high_threshold[key]), \
+            f"Got same value for '{key}' metric with low and high thresholds"
 
 
 def move_batch_to_expected_device(batch: Dict[str, List], use_gpu: bool) -> Dict:

--- a/hi-ml-histopathology/testhisto/testhisto/models/test_deepmil.py
+++ b/hi-ml-histopathology/testhisto/testhisto/models/test_deepmil.py
@@ -113,6 +113,23 @@ def test_lightningmodule(
             assert torch.all(score <= 1)
 
 
+def validate_metric_inputs(scores: torch.Tensor, labels: torch.Tensor) -> None:
+    def is_integral(x: torch.Tensor) -> bool:
+        return (x == x.long()).all()  # type: ignore
+
+    assert scores.shape == labels.shape
+    assert torch.is_floating_point(scores), "Received scores with integer dtype"
+    assert not is_integral(scores), "Received scores with integral values"
+    assert is_integral(labels), "Received labels with floating-point values"
+
+
+def add_callback(fn: Callable, callback: Callable) -> Callable:
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        callback(*args, **kwargs)
+        return fn(*args, **kwargs)
+    return wrapper
+
+
 def test_metrics() -> None:
     input_dim = (128,)
     module = DeepMILModule(
@@ -144,9 +161,15 @@ def test_metrics() -> None:
         bags.append(sample)
     batch = default_collate(bags)
 
+    # ================
     # Test that the module metrics match manually computed metrics with the correct inputs
     module_metrics_dict = module.test_metrics
     independent_metrics_dict = module.get_metrics()
+
+    # Patch the metrics to check that the inputs are valid. In particular, test that the scores
+    # do not have integral values, which would suggest that hard labels were passed instead.
+    for metric_obj in module_metrics_dict.values():
+        metric_obj.update = add_callback(metric_obj.update, validate_metric_inputs)
 
     results = module.test_step(batch, 0)
     predicted_probs = results[ResultsKey.PROB]
@@ -157,11 +180,9 @@ def test_metrics() -> None:
         expected_value = independent_metrics_dict[key](predicted_probs, true_labels)
         assert torch.allclose(value, expected_value), f"Discrepancy in '{key}' metric"
 
-    # TODO: Intercept calls to Metric.update() and check input dtype and num unique
-
-    # Test that thresholded metrics (e.g. accuracy, precision, etc.) change
-    # as the threshold is varied. If they don't, it's a sign that the inputs
-    # are hard labels instead of continuous scores.
+    # ================
+    # Test that thresholded metrics (e.g. accuracy, precision, etc.) change as the threshold is varied.
+    # If they don't, it suggests the inputs are hard labels instead of continuous scores.
     thresholded_metrics_keys = [key for key, metric in module_metrics_dict.items()
                                 if hasattr(metric, 'threshold')]
 

--- a/hi-ml/src/health_ml/model_trainer.py
+++ b/hi-ml/src/health_ml/model_trainer.py
@@ -216,6 +216,7 @@ def model_train(checkpoint_path: Optional[Path],
 
     logging.info("Starting training")
     trainer.fit(lightning_model, datamodule=data_module)
+    assert trainer.logger is not None
     trainer.logger.finalize('success')
 
     # DDP will start multiple instances of the runner, one for each GPU. Those should terminate here after training.

--- a/hi-ml/src/health_ml/utils/logging.py
+++ b/hi-ml/src/health_ml/utils/logging.py
@@ -273,6 +273,7 @@ class AzureMLProgressBar(ProgressBarBase):
         if not should_update:
             return
         prefix = f"{self.stage}"
+        assert self.trainer is not None and self.trainer.lightning_module is not None  # for pyright
         if self.stage in [self.PROGRESS_STAGE_TRAIN, self.PROGRESS_STAGE_VAL]:
             prefix += f" epoch {self.trainer.current_epoch}"
         if self.stage == self.PROGRESS_STAGE_TRAIN:

--- a/hi-ml/testhiml/testhiml/test_split_dataset.py
+++ b/hi-ml/testhiml/testhiml/test_split_dataset.py
@@ -86,8 +86,8 @@ def _get_test_df() -> Tuple[DataFrame, List[str], List[str], List[str]]:
         CSV_GROUP_HEADER: [i // 5 for i in range(0, 100)],
         "other": list(range(0, 100))
     }
-    assert all(np.bincount(test_data[CSV_GROUP_HEADER]) > 1), "Found singleton groups"
-    assert len(np.unique(test_data[CSV_GROUP_HEADER])) > 1, "Found a single group"
+    assert all(np.bincount(test_data[CSV_GROUP_HEADER]) > 1), "Found singleton groups"  # type: ignore
+    assert len(np.unique(test_data[CSV_GROUP_HEADER])) > 1, "Found a single group"  # type: ignore
     train_ids, test_ids, val_ids = list(range(0, 50)), list(range(50, 75)), list(range(75, 100))
     test_df = DataFrame(test_data, columns=list(test_data.keys()))
     return test_df, list(map(str, test_ids)), list(map(str, train_ids)), list(map(str, val_ids))


### PR DESCRIPTION
Fixes a bug in `DeepMILModule` whereby predicted hard labels were being passed to classification metrics, instead of the intended continuous probability scores. This PR also adds tests to ensure this won't happen anymore.