### PR TITLE
Show workspace name in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ the environment file since it is necessary for the augmentations.
 
 ### Changed
 
+- ([#196](https://github.com/microsoft/hi-ml/pull/196)) Show current workspace name in error message.
+
 ### Fixed
 - ([#179](https://github.com/microsoft/hi-ml/pull/179)) HEDJitter was jittering the D channel as well. StainNormalization was relying on skimage.
 

--- a/hi-ml-azure/src/health_azure/datasets.py
+++ b/hi-ml-azure/src/health_azure/datasets.py
@@ -33,8 +33,8 @@ def get_datastore(workspace: Workspace, datastore_name: str) -> Datastore:
                          f"However, the workspace has {len(existing_stores)} datastores: {existing_stores}")
     if datastore_name in datastores:
         return datastores[datastore_name]
-    raise ValueError(f"Datastore {datastore_name} was not found in the workspace. Existing datastores: "
-                     f"{existing_stores}")
+    raise ValueError(f"Datastore \"{datastore_name}\" was not found in the \"{workspace.name}\" workspace. "
+                     f"Existing datastores: {existing_stores}")
 
 
 def get_or_create_dataset(workspace: Workspace, datastore_name: str, dataset_name: str) -> FileDataset:

--- a/hi-ml-azure/testazure/testazure/test_datasets.py
+++ b/hi-ml-azure/testazure/testazure/test_datasets.py
@@ -39,7 +39,7 @@ def test_get_datastore() -> None:
     workspace = DEFAULT_WORKSPACE.workspace
     with pytest.raises(ValueError) as ex:
         get_datastore(workspace=workspace, datastore_name=does_not_exist)
-    assert f"Datastore {does_not_exist} was not found" in str(ex)
+    assert f"Datastore \"{does_not_exist}\" was not found" in str(ex)
 
     # Trying to get a datastore without name should only work if there is a single datastore
     assert len(workspace.datastores) > 1


### PR DESCRIPTION
The current error message is

```
Datastore X was not found in the workspace. Existing datastores: A, B, C
```

I have just modified to include the workspace name:

```
Datastore "X" was not found in the "Y" workspace. Existing datastores: A, B, C
```