### PR TITLE
FIX: Config loader fails when using relative directories

### DIFF
--- a/hi-ml-azure/src/health_azure/paths.py
+++ b/hi-ml-azure/src/health_azure/paths.py
@@ -18,7 +18,7 @@ def is_himl_used_from_git_repo() -> bool:
 
     :return: False if HI-ML is installed as a package, True if used via source from git.
     """
-    health_ml_root = Path(__file__).parent.parent
+    health_ml_root = Path(__file__).resolve().parent.parent
     logging.debug(f"health_ml root: {health_ml_root}")
     if health_ml_root.parent.stem == "site-packages":
         return False
@@ -44,4 +44,5 @@ def git_repo_root_folder() -> Path:
     """
     if not is_himl_used_from_git_repo():
         raise ValueError("This function can only be used if the HI-ML package is used directly from the git repo.")
-    return Path(__file__).parent.parent.parent.parent
+    current_file = Path(__file__).resolve()
+    return current_file.parent.parent.parent.parent

--- a/hi-ml-azure/testazure/testazure/test_azure_util.py
+++ b/hi-ml-azure/testazure/testazure/test_azure_util.py
@@ -64,7 +64,7 @@ def test_find_file(tmp_path: Path) -> None:
     os.chdir(start_path)
     found_file = util.find_file_in_parent_to_pythonpath(file_name)
     assert found_file
-    with mock.patch.dict(os.environ, {"PYTHONPATH": str(python_root.absolute())}):
+    with mock.patch.dict(os.environ, {"PYTHONPATH": str(python_root)}):
         found_file = util.find_file_in_parent_to_pythonpath(file_name)
         assert not found_file
     os.chdir(where_are_we_now)

--- a/hi-ml/src/health_ml/configs/hello_world.py
+++ b/hi-ml/src/health_ml/configs/hello_world.py
@@ -240,7 +240,7 @@ class HelloWorld(LightningContainer):
 
     def __init__(self) -> None:
         super().__init__()
-        self.local_dataset_dir = Path(__file__).parent
+        self.local_dataset_dir = Path(__file__).resolve().parent
         self.max_epochs = 20
 
     # This method must be overridden by any subclass of LightningContainer. It returns the model that you wish to

--- a/hi-ml/src/health_ml/deep_learning_config.py
+++ b/hi-ml/src/health_ml/deep_learning_config.py
@@ -92,10 +92,10 @@ class ExperimentFolderHandler(Parameterized):
         if is_offline_run or output_to:
             if output_to:
                 logging.info(f"All results will be written to the specified output folder {output_to}")
-                root = Path(output_to).absolute()
+                root = Path(output_to).resolve()
             else:
                 logging.info("All results will be written to a subfolder of the project root folder.")
-                root = project_root.absolute() / DEFAULT_AML_UPLOAD_DIR
+                root = project_root.resolve() / DEFAULT_AML_UPLOAD_DIR
 
             timestamp = create_unique_timestamp_id()
             run_folder = root / f"{timestamp}_{model_name}"

--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -213,7 +213,8 @@ class Runner:
             try:
                 workspace = get_workspace()
             except ValueError:
-                logging.warning("No configuration file for an AzureML workspace was found.")
+                raise ValueError("Unable to submit the script to AzureML because no workspace configuration file "
+                                 "(config.json) was found.")
         default_datastore = workspace.get_default_datastore().name if workspace is not None else ""
 
         local_datasets = self.lightning_container.local_datasets
@@ -241,9 +242,6 @@ class Runner:
                     temp_conda = root_folder / f"temp_environment-{uuid.uuid4().hex[:8]}.yml"
                     merge_conda_files(conda_files, temp_conda, pip_files=pip_requirements_files)
 
-                if workspace is None:
-                    raise ValueError("Unable to submit the script to AzureML because no workspace configuration file "
-                                     "(config.json) was found.")
                 if not self.experiment_config.cluster:
                     raise ValueError("You need to specify a cluster name via '--cluster NAME' to submit "
                                      "the script to run in AzureML")

--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -15,7 +15,7 @@ import matplotlib
 from azureml.core import Workspace
 
 # Add hi-ml packages to sys.path so that AML can find them if we are using the runner directly from the git repo
-himl_root = Path(__file__).absolute().parent.parent.parent.parent
+himl_root = Path(__file__).resolve().parent.parent.parent.parent
 folders_to_add = [himl_root / "hi-ml" / "src",
                   himl_root / "hi-ml-azure" / "src",
                   himl_root / "hi-ml-histopathology" / "src"]
@@ -312,6 +312,7 @@ def run(project_root: Path) -> Tuple[LightningContainer, AzureRunInfo]:
     :return: If submitting to AzureML, returns the model configuration that was used for training,
     including commandline overrides applied (if any). For details on the arguments, see the constructor of Runner.
     """
+    print(f"project root: {project_root}")
     runner = Runner(project_root)
     return runner.run()
 

--- a/hi-ml/src/health_ml/utils/common_utils.py
+++ b/hi-ml/src/health_ml/utils/common_utils.py
@@ -224,7 +224,11 @@ def get_all_environment_files(project_root: Path, additional_files: Optional[Lis
         env_file = utils.find_file_in_parent_folders(
             file_name=paths.ENVIRONMENT_YAML_FILE_NAME, stop_at_path=[git_repo_root]
         )
-        assert env_file is not None, "Expected to find at least the environment definition file at repo root"
+        if env_file is None:
+            # Searching for Conda file starts at current working directory, meaning it might not find
+            # the file if cwd is outside the git repo
+            env_file = git_repo_root / paths.ENVIRONMENT_YAML_FILE_NAME
+            assert env_file.is_file(), "Expected to find at least the environment definition file at repo root"
         logging.info(f"Using Conda environment in {env_file}")
         env_files.append(env_file)
     elif project_yaml.exists():

--- a/hi-ml/testhiml/testhiml/utils/fixed_paths_for_tests.py
+++ b/hi-ml/testhiml/testhiml/utils/fixed_paths_for_tests.py
@@ -2,7 +2,6 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -17,7 +16,7 @@ def tests_root_directory(path: Optional[PathOrString] = None) -> Path:
 
     :return: The full path to the repository's root directory, with symlinks resolved if any.
     """
-    root = Path(os.path.realpath(__file__)).parent.parent.parent
+    root = Path(__file__).resolve().parent.parent.parent
     return root / path if path else root
 
 

--- a/hi-ml/testhiml/testhiml/utils/slide_image_loading/src/Histopathology/datasets/panda_dataset.py
+++ b/hi-ml/testhiml/testhiml/utils/slide_image_loading/src/Histopathology/datasets/panda_dataset.py
@@ -42,8 +42,8 @@ class PandaDataset(Dataset):
         image_id = self.train_df.index[index]
         return {
             'image_id': image_id,
-            'image': str(self._get_image_path(image_id).absolute()),
-            'mask': str(self._get_mask_path(image_id).absolute()),
+            'image': str(self._get_image_path(image_id).resolve()),
+            'mask': str(self._get_mask_path(image_id).resolve()),
             **self.train_df.loc[image_id].to_dict()
         }
 


### PR DESCRIPTION
Config loader fails depending on whether runner is called via path that involves `..` or not.

Bug fix is the change in `runner.py`, all other changes are just places where we might get wrong results because of `Path.absolute`

Other changes improve search for conda environment files in corner cases

Please follow the guidelines for PRs contained [here](docs/source/contributing.md). Checklist:

- [ ] Ensure that your PR is small, and implements one change.
- [ ] Add unit tests for all functions that you introduced or modified.
- [ ] Run PyCharm's code cleanup tools on your Python files.
- [ ] Ensure that documentation renders correctly in Sphinx (run Sphinx via `make html` in the `docs folder)
- [ ] Link the correct GitHub issue for tracking.
- [ ] When merging your PR, **replace the default merge message** with a brief description of your PR,
and if needed a motivation why that change was required.