### PR TITLE
FIX: update base_module to avoid cache being reused when cachemode is None

### DIFF
--- a/hi-ml-histopathology/src/histopathology/datamodules/base_module.py
+++ b/hi-ml-histopathology/src/histopathology/datamodules/base_module.py
@@ -102,7 +102,7 @@ class TilesDataModule(LightningDataModule):
             self._load_dataset(self.test_dataset, stage='test', shuffle=True)
 
     def _dataset_pickle_path(self, stage: str) -> Optional[Path]:
-        if self.cache_dir is None or self.cache_mode==CacheMode.NONE:
+        if self.cache_dir is None or self.cache_mode == CacheMode.NONE:
             return None
         return self.cache_dir / f"{stage}_dataset.pt"
 

--- a/hi-ml-histopathology/src/histopathology/datamodules/base_module.py
+++ b/hi-ml-histopathology/src/histopathology/datamodules/base_module.py
@@ -102,7 +102,7 @@ class TilesDataModule(LightningDataModule):
             self._load_dataset(self.test_dataset, stage='test', shuffle=True)
 
     def _dataset_pickle_path(self, stage: str) -> Optional[Path]:
-        if self.cache_dir is None:
+        if self.cache_dir is None or self.cache_mode==CacheMode.NONE:
             return None
         return self.cache_dir / f"{stage}_dataset.pt"
 


### PR DESCRIPTION
One line fix to avoid cache being reused when cache_mode is None. It also allows to run the debugger in vscode without being forced to manually remove the cache