### PR TITLE
BUG: Fix renaming of outputs folders in Azure ML

### DIFF
--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
 import tempfile
 from argparse import (
@@ -1786,6 +1787,36 @@ def download_files_from_hyperdrive_children(
                 downloaded_file_paths.append(str(downloaded_file_path))
 
     return downloaded_file_paths
+
+
+def replace_directory(source: Path, target: Path) -> None:
+    """
+    Safely move the contents of a source directory, deleting any files at the target location.
+
+    Because of how Azure ML mounts output folders, it is impossible to move or rename existing files. Therefore, if
+    running in Azure ML, this function creates a copy of the contents of `source`, then deletes the original files.
+
+    :param source: Source directory whose contents should be moved.
+    :param target: Target directory into which the contents should be moved. If not empty, all of its contents will be
+        deleted first.
+    """
+    if not source.is_dir():
+        raise ValueError(f"Source must be a directory, but got {source}")
+
+    if is_running_in_azure_ml():
+        if target.exists():
+            shutil.rmtree(target)
+        assert not target.exists()
+
+        shutil.copytree(source, target)
+        shutil.rmtree(source)
+    else:
+        # Outside of Azure ML, it should be much faster to rename the directory
+        # than to copy all contents then delete, especially for large dirs.
+        source.replace(target)
+
+    assert target.exists()
+    assert not source.exists()
 
 
 def create_aml_run_object(

--- a/hi-ml-azure/testazure/testazure/test_azure_util.py
+++ b/hi-ml-azure/testazure/testazure/test_azure_util.py
@@ -1040,6 +1040,36 @@ from health_azure.utils import download_files_from_run_id""",
     render_and_run_test_script(tmp_path / "foo", RunTarget.AZUREML, extra_options, extra_args=[], expected_pass=True)
 
 
+def test_replace_directory(tmp_path: Path) -> None:
+    extra_options = {
+        "imports": """
+import sys
+import shutil
+from pathlib import Path
+from health_azure.utils import replace_directory
+""",
+
+        "body": """
+output_dir = Path("outputs/test_outputs")
+output_dir.mkdir(parents=True, exist_ok=True)
+file_name = "hello.txt"
+(output_dir / file_name).write_text("Hello World!")
+assert (output_dir / file_name).exists()
+new_output_dir = output_dir.parent / "more_test_outputs"
+
+replace_directory(output_dir, new_output_dir)
+
+assert not output_dir.exists()
+assert (new_output_dir / file_name).exists()
+"""
+    }
+
+    render_and_run_test_script(tmp_path, RunTarget.LOCAL, extra_options, extra_args=[], expected_pass=True)
+    print("Local run finished")
+
+    render_and_run_test_script(tmp_path / "foo", RunTarget.AZUREML, extra_options, extra_args=[], expected_pass=True)
+
+
 def test_is_global_rank_zero() -> None:
     with mock.patch.dict(os.environ, {util.ENV_NODE_RANK: "0", util.ENV_GLOBAL_RANK: "0", util.ENV_LOCAL_RANK: "0"}):
         assert not util.is_global_rank_zero()

--- a/hi-ml-histopathology/src/histopathology/utils/output_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/output_utils.py
@@ -15,6 +15,7 @@ from ruamel.yaml import YAML
 from torchmetrics.classification.confusion_matrix import ConfusionMatrix
 from torchmetrics.metric import Metric
 
+from health_azure.utils import replace_directory
 from histopathology.datasets.base_dataset import SlidesDataset
 from histopathology.utils.metrics_utils import (plot_attention_tiles, plot_heatmap_overlay,
                                                 plot_normalized_confusion_matrix, plot_scores_hist, plot_slide,
@@ -359,7 +360,8 @@ class DeepMILOutputsHandler:
             # First move existing outputs to a temporary directory, to avoid mixing
             # outputs of different epochs in case writing fails halfway through
             if self.validation_outputs_dir.exists():
-                self.validation_outputs_dir.replace(self.previous_validation_outputs_dir)
+                replace_directory(source=self.validation_outputs_dir,
+                                  target=self.previous_validation_outputs_dir)
 
             self._save_outputs(epoch_results, metrics_dict, self.validation_outputs_dir)
 


### PR DESCRIPTION
Adds a `health_azure.utils.replace_directory()` function to enable "renaming" folders in AML runs (in practice: clear destination, copy contents, delete originals). The special logic is necessary because blob storage does not allow directly moving/renaming files. 

This change should fix an issue with `DeepMILOutputsHandler` running in AML, whereby it needs to move previous-best validation outputs to a temporary folder to avoid partial overwrites.