### PR TITLE
BUG: Enable outputs handler to work in DDP

### DIFF
--- a/hi-ml-histopathology/src/histopathology/models/deepmil.py
+++ b/hi-ml-histopathology/src/histopathology/models/deepmil.py
@@ -273,11 +273,16 @@ class DeepMILModule(LightningModule):
 
     def validation_epoch_end(self, epoch_results: EpochResultsType) -> None:
         if self.outputs_handler:
-            self.outputs_handler.save_validation_outputs(epoch_results=epoch_results,
-                                                         metrics_dict=self.get_metrics_dict('val'),
-                                                         epoch=self.current_epoch)
+            self.outputs_handler.save_validation_outputs(
+                epoch_results=epoch_results,
+                metrics_dict=self.get_metrics_dict('val'),
+                epoch=self.current_epoch,
+                is_global_rank_zero=self.global_rank == 0
+            )
 
     def test_epoch_end(self, epoch_results: EpochResultsType) -> None:
         if self.outputs_handler:
-            self.outputs_handler.save_test_outputs(epoch_results=epoch_results,
-                                                   metrics_dict=self.get_metrics_dict('test'))
+            self.outputs_handler.save_test_outputs(
+                epoch_results=epoch_results,
+                is_global_rank_zero=self.global_rank == 0
+            )

--- a/hi-ml-histopathology/src/histopathology/utils/metrics_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/metrics_utils.py
@@ -37,7 +37,10 @@ def select_k_tiles(results: Dict, n_tiles: int = 5, n_slides: int = 5, label: in
     :param return_col: column name of the values we want to return for each tile
     :return: tuple containing the slides id, the slide score, the tile ids, the tiles scores
     """
+    # TODO: Refactor into separate functions to select slides by probabilities and tiles by attentions
     tmp_s = [(results[prob_col][i][label], i) for i, gt in enumerate(results[gt_col]) if gt == label]  # type ignore
+    if len(tmp_s) == 0:
+        return []
     if select[0] == 'lowest_pred':
         tmp_s.sort(reverse=False)
     elif select[0] == 'highest_pred':

--- a/hi-ml-histopathology/src/histopathology/utils/output_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/output_utils.py
@@ -71,6 +71,12 @@ def normalize_dict_for_df(dict_old: Dict[ResultsKey, Any]) -> Dict[str, Any]:
 
 
 def gather_results(epoch_results: EpochResultsType) -> EpochResultsType:
+    """Gather epoch results across all DDP processes into a single list.
+
+    :param epoch_results: The collected epoch results (i.e. list of batch results) for the current process.
+    :return: A list in the same format as `epoch_results`, containing batch results from all DDP processes. Returns
+        `epoch_results` unchanged if not in distributed mode.
+    """
     if torch.distributed.is_initialized():
         world_size = torch.distributed.get_world_size()
         if world_size > 1:
@@ -81,6 +87,13 @@ def gather_results(epoch_results: EpochResultsType) -> EpochResultsType:
 
 
 def collate_results(epoch_results: EpochResultsType) -> ResultsType:
+    """Convert a list of results dictionaries into a dictionary of lists.
+
+    :param epoch_results: Collected epoch results, whose elements are dictionaries of :py:class:`ResultsKey` to the
+        outputs of the respective batch (i.e. indexed as `epoch_results[batch_index][results_key]`).
+    :return: A dictionary mapping each :py:class:`ResultsKey` to a list containing the corresponding outputs for every
+        batch (i.e. indexed as `collated_results[results_key][batch_index]`).
+    """
     results: ResultsType = {}
     for key in epoch_results[0].keys():
         results[key] = []

--- a/hi-ml-histopathology/src/histopathology/utils/output_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/output_utils.py
@@ -80,7 +80,7 @@ def gather_results(epoch_results: EpochResultsType) -> EpochResultsType:
     if torch.distributed.is_initialized():
         world_size = torch.distributed.get_world_size()
         if world_size > 1:
-            object_list: EpochResultsType = [None] * world_size
+            object_list: EpochResultsType = [None] * world_size  # type: ignore
             torch.distributed.all_gather_object(object_list, epoch_results)
             epoch_results = list(chain(*object_list))
     return epoch_results

--- a/hi-ml-histopathology/src/histopathology/utils/output_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/output_utils.py
@@ -272,14 +272,14 @@ class OutputsPolicy:
         YAML().dump(contents, self.best_metric_file_path)
 
     def should_save_validation_outputs(self, metrics_dict: Mapping[MetricsKey, Metric], epoch: int,
-                                       is_global_rank_zero: bool) -> bool:
+                                       is_global_rank_zero: bool = True) -> bool:
         """Determine whether validation outputs should be saved given the current epoch's metrics.
 
         :param metrics_dict: Current epoch's metrics dictionary from
             :py:class:`~histopathology.models.deepmil.DeepMILModule`.
         :param epoch: Current epoch number.
-        :param is_global_rank_zero: Whether this is the global rank-0 process in distributed scenarios. Set to `True`
-            if not running in distributed mode.
+        :param is_global_rank_zero: Whether this is the global rank-0 process in distributed scenarios.
+            Set to `True` (default) if running a single process.
         :return: Whether this is the best validation epoch so far.
         """
         # The metric needs to be computed on all ranks to allow synchronisation
@@ -301,11 +301,11 @@ class OutputsPolicy:
 
         return is_best
 
-    def should_save_test_outputs(self, is_global_rank_zero: bool) -> bool:
+    def should_save_test_outputs(self, is_global_rank_zero: bool = True) -> bool:
         """Determine whether test outputs should be saved.
 
-        :param is_global_rank_zero: Whether this is the global rank-0 process in distributed scenarios. Set to `True`
-            if not running in distributed mode.
+        :param is_global_rank_zero: Whether this is the global rank-0 process in distributed scenarios.
+            Set to `True` (default) if running a single process.
         """
         # This is implemented as a method in case we want to add custom logic in the future
         return is_global_rank_zero
@@ -387,14 +387,14 @@ class DeepMILOutputsHandler:
         # save_confusion_matrix(conf_matrix, class_names=self.class_names, figures_dir=figures_dir)
 
     def save_validation_outputs(self, epoch_results: EpochResultsType, metrics_dict: Mapping[MetricsKey, Metric],
-                                epoch: int, is_global_rank_zero: bool) -> None:
+                                epoch: int, is_global_rank_zero: bool = True) -> None:
         """Render and save validation epoch outputs, according to the configured :py:class:`OutputsPolicy`.
 
         :param epoch_results: Aggregated results from all epoch batches, as passed to :py:meth:`validation_epoch_end()`.
         :param metrics_dict: Current epoch's validation metrics dictionary from
             :py:class:`~histopathology.models.deepmil.DeepMILModule`.
-        :param is_global_rank_zero: Whether this is the global rank-0 process in distributed scenarios. Set to `True`
-            if not running in distributed mode.
+        :param is_global_rank_zero: Whether this is the global rank-0 process in distributed scenarios.
+            Set to `True` (default) if running a single process.
         :param epoch: Current epoch number.
         """
         # All DDP processes must reach this point to allow synchronising epoch results
@@ -414,13 +414,13 @@ class DeepMILOutputsHandler:
             if self.previous_validation_outputs_dir.exists():
                 shutil.rmtree(self.previous_validation_outputs_dir)
 
-    def save_test_outputs(self, epoch_results: EpochResultsType, is_global_rank_zero: bool) -> None:
+    def save_test_outputs(self, epoch_results: EpochResultsType, is_global_rank_zero: bool = True) -> None:
         """Render and save test epoch outputs.
 
         :param epoch_results: Aggregated results from all epoch batches, as passed to :py:meth:`test_epoch_end()`.
         :param metrics_dict: Test metrics dictionary from :py:class:`~histopathology.models.deepmil.DeepMILModule`.
-        :param is_global_rank_zero: Whether this is the global rank-0 process in distributed scenarios. Set to `True`
-            if not running in distributed mode.
+        :param is_global_rank_zero: Whether this is the global rank-0 process in distributed scenarios.
+            Set to `True` (default) if running a single process.
         """
         # All DDP processes must reach this point to allow synchronising epoch results
         gathered_epoch_results = gather_results(epoch_results)

--- a/hi-ml-histopathology/testhisto/testhisto/utils/test_output_utils.py
+++ b/hi-ml-histopathology/testhisto/testhisto/utils/test_output_utils.py
@@ -13,7 +13,7 @@ from torchmetrics.metric import Metric
 
 from histopathology.utils.naming import MetricsKey, ResultsKey
 from histopathology.utils.output_utils import (BatchResultsType, DeepMILOutputsHandler, EpochResultsType, OutputsPolicy,
-                                               ResultsType, collate_results, gather_results)
+                                               collate_results, gather_results)
 
 _PRIMARY_METRIC_KEY = MetricsKey.ACC
 

--- a/hi-ml-histopathology/testhisto/testhisto/utils/utils_testhisto.py
+++ b/hi-ml-histopathology/testhisto/testhisto/utils/utils_testhisto.py
@@ -4,10 +4,11 @@
 #  ------------------------------------------------------------------------------------------
 import os
 from pathlib import Path
-from typing import Any, Callable, Collection, Mapping, Optional
+from typing import Any, Callable, Collection, Mapping, Optional, Sequence
 
 import numpy as np
 import torch
+import torch.distributed
 from PIL import Image
 
 from health_azure.utils import PathOrString
@@ -85,7 +86,7 @@ def full_ml_test_data_path(suffix: str = "") -> Path:
     return test_data_dir / suffix
 
 
-def _run_distributed_process(rank: int, world_size: int, fn: Callable[[int, int, str], None],
+def _run_distributed_process(rank: int, world_size: int, fn: Callable[..., None], args: Sequence[Any] = (),
                              backend: str = 'nccl') -> None:
     """Run a function in the current subprocess within a PyTorch Distributed context.
 
@@ -93,26 +94,41 @@ def _run_distributed_process(rank: int, world_size: int, fn: Callable[[int, int,
 
     Reference: https://pytorch.org/tutorials/intermediate/dist_tuto.html
 
-    :param rank: Process rank.
+    :param rank: Rank of the current process.
     :param world_size: Total number of distributed subprocesses.
-    :param fn: Function to execute in this subprocess, taking as arguments the process rank, `world_size`, and device.
+    :param fn: Function to execute in each subprocess, accepting least the following keyword arguments:
+
+        * `rank` (`int`): The (global) rank assigned to the subprocess executing the function.
+        * `world_size` (`int`): Total number of distributed subprocesses.
+        * `device` (`str`): CUDA device allocated to this process (e.g. `'cuda:1'`).
+
+    :param args: Any positional arguments to be passed to `fn`, which will be called as
+        ``fn(*args, rank=..., world_size=..., device=...)``.
     :param backend: Distributed communication backend (default: `'nccl'`).
     """
+    # TODO: Add timeouts and proper handling of CUDA/NCCL errors
     os.environ['MASTER_ADDR'] = '127.0.0.1'
     os.environ['MASTER_PORT'] = '29500'
     torch.distributed.init_process_group(backend, rank=rank, world_size=world_size)
     torch.cuda.set_device(rank)
     device = f'cuda:{rank}'
-    fn(rank, world_size, device)
+    fn(*args, rank=rank, world_size=world_size, device=device)
     torch.distributed.destroy_process_group()
 
 
-def run_distributed(fn: Callable[[int, int, str], None], world_size: int) -> None:
+def run_distributed(fn: Callable[..., None], args: Sequence[Any] = (), world_size: int = 1) -> None:
     """Run a function in multiple subprocesses using PyTorch Distributed.
 
     Reference: https://pytorch.org/tutorials/intermediate/dist_tuto.html
 
-    :param fn: Function to execute in each subprocess, taking as arguments the process rank, `world_size`, and device.
+    :param fn: Function to execute in each subprocess, accepting least the following keyword arguments:
+
+        * `rank` (`int`): The (global) rank assigned to the subprocess executing the function.
+        * `world_size` (`int`): Total number of distributed subprocesses.
+        * `device` (`str`): CUDA device allocated to this process (e.g. `'cuda:1'`).
+
+    :param args: Any positional arguments to be passed to `fn`, which will be called as
+        ``fn(*args, rank=..., world_size=..., device=...)``.
     :param world_size: Total number of distributed subprocesses to spawn.
     """
-    torch.multiprocessing.spawn(_run_distributed_process, args=(world_size, fn), nprocs=world_size)
+    torch.multiprocessing.spawn(_run_distributed_process, args=(world_size, fn, args), nprocs=world_size)

--- a/hi-ml-histopathology/testhisto/testhisto/utils/utils_testhisto.py
+++ b/hi-ml-histopathology/testhisto/testhisto/utils/utils_testhisto.py
@@ -85,7 +85,8 @@ def full_ml_test_data_path(suffix: str = "") -> Path:
     return test_data_dir / suffix
 
 
-def _run_distributed_process(rank: int, world_size: int, fn: Callable[[int, int], None], backend: str = 'nccl') -> None:
+def _run_distributed_process(rank: int, world_size: int, fn: Callable[[int, int, str], None],
+                             backend: str = 'nccl') -> None:
     """Run a function in the current subprocess within a PyTorch Distributed context.
 
     This function should be called with :py:func:`torch.multiprocessing.spawn()`.
@@ -94,23 +95,24 @@ def _run_distributed_process(rank: int, world_size: int, fn: Callable[[int, int]
 
     :param rank: Process rank.
     :param world_size: Total number of distributed subprocesses.
-    :param fn: Function to execute in this subprocess, taking as arguments the process rank and the `world_size`.
+    :param fn: Function to execute in this subprocess, taking as arguments the process rank, `world_size`, and device.
     :param backend: Distributed communication backend (default: `'nccl'`).
     """
     os.environ['MASTER_ADDR'] = '127.0.0.1'
     os.environ['MASTER_PORT'] = '29500'
     torch.distributed.init_process_group(backend, rank=rank, world_size=world_size)
     torch.cuda.set_device(rank)
-    fn(rank, world_size)
+    device = f'cuda:{rank}'
+    fn(rank, world_size, device)
     torch.distributed.destroy_process_group()
 
 
-def run_distributed(fn: Callable[[int, int], None], world_size: int) -> None:
+def run_distributed(fn: Callable[[int, int, str], None], world_size: int) -> None:
     """Run a function in multiple subprocesses using PyTorch Distributed.
 
     Reference: https://pytorch.org/tutorials/intermediate/dist_tuto.html
 
-    :param fn: Function to execute in each subprocess, taking as arguments the process rank and the `world_size`.
+    :param fn: Function to execute in each subprocess, taking as arguments the process rank, `world_size`, and device.
     :param world_size: Total number of distributed subprocesses to spawn.
     """
     torch.multiprocessing.spawn(_run_distributed_process, args=(world_size, fn), nprocs=world_size)


### PR DESCRIPTION
This PR ensures that epoch results passed to an outputs handler are synchronised (i.e. gathered) across DDP processes, and the processing and saving of the gathered outputs now happens only on the global rank-0 process. Fixes #259.

Also includes a check for empty list in `metrics_utils.select_k_tiles()` to fix #260.

<!--
## Guidelines

Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:

- Ensure that your PR is small, and implements one change
- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/CONTRIBUTING.md))
- Link the correct GitHub issue for tracking
- Add unit tests for all functions that you introduced or modified
- Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder

## Change the default merge message

When completing your PR, you will be asked for a title and an optional extended description. By default, the extended description will be a concatenation of the individual
commit messages. Please DELETE/REPLACE that with a human readable extended description for non-trivial PRs.
-->
