### PR TITLE
BUG: Add upperbound to jinja2 in requirements file

### DIFF
--- a/hi-ml/run_requirements.txt
+++ b/hi-ml/run_requirements.txt
@@ -1,6 +1,6 @@
 dataclasses-json==0.5.2
 hi-ml-azure>=0.1.8
-jinja2>=3.0.2
+jinja2>=3.0.2, <3.1.0
 matplotlib>=3.4.3
 opencv-python-headless>=4.5.1.48
 pandas>=1.3.4


### PR DESCRIPTION
Added Upper bound of 3.1.0 for jinja2 in requirements.txt. 
Fixes https://github.com/microsoft/hi-ml/issues/263
