### PR TITLE
BUG: Pin jinja2 to avoid bug in latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 Early versions of this toolbox used a manually created changelog. As of March 2022, we have switched to using Github's auto-generated changelog.
-If you would like to view the changelog for a particular release, you can do so on the [Releases page](https://github.com/microsoft/hi-ml/releases): 
+If you would like to view the changelog for a particular release, you can do so on the [Releases page](https://github.com/microsoft/hi-ml/releases):
 Each release contains a link for "Full Changelog"
 
 
@@ -32,11 +32,13 @@ the environment file since it is necessary for the augmentations.
 
 ### Fixed
 
+- ([#266]https://github.com/microsoft/hi-ml/pull/266)) Pin jinja2 package to avoid 'No attribute Markup' bug in version 3.1.0
 - ([#246](https://github.com/microsoft/hi-ml/pull/246)) Added tolerance to `test_attentionlayers.py`.
 - ([#198](https://github.com/microsoft/hi-ml/pull/198)) Dependencies for histopathology folder are no longer specified in `test_requirements.txt`, but correctly in the histopathology Conda environment.
 - ([#188](https://github.com/microsoft/hi-ml/pull/188)) Updated DeepSMILES models. Now they are uptodate with innereye-dl.
 - ([#179](https://github.com/microsoft/hi-ml/pull/179)) HEDJitter was jittering the D channel as well. StainNormalization was relying on skimage.
 - ([#195](https://github.com/microsoft/hi-ml/pull/195)) Fix DeepMIL metrics bug whereby hard labels were used instead of probabilities.
+
 
 ### Removed
 

--- a/hi-ml/run_requirements.txt
+++ b/hi-ml/run_requirements.txt
@@ -1,6 +1,6 @@
 dataclasses-json==0.5.2
 hi-ml-azure>=0.1.8
-jinja2>=3.0.2
+jinja2==3.0.2
 matplotlib>=3.4.3
 opencv-python-headless>=4.5.1.48
 pandas>=1.3.4


### PR DESCRIPTION
Pin version of jinja2 to avoid bug in latest version (3.1.0) that causes the following error: `AttributeError: module 'jinja2' has no attribute 'Markup'`

Related to [this issue](https://github.com/microsoft/hi-ml/issues/263l)