### PR TITLE
BUG: Correct pythonpath separator character in VS code settings file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,7 +68,7 @@
     ],
     "terminal.integrated.defaultProfile.windows": "Command Prompt",
     "terminal.integrated.env.windows": {
-        "PYTHONPATH":"${workspaceFolder}/hi-ml/src:${workspaceFolder}/hi-ml-azure/src:${workspaceFolder}/hi-ml-histopathology/src"
+        "PYTHONPATH":"${workspaceFolder}/hi-ml/src;${workspaceFolder}/hi-ml-azure/src;${workspaceFolder}/hi-ml-histopathology/src"
     },
     "terminal.integrated.env.linux": {
         "PYTHONPATH":"${workspaceFolder}/hi-ml/src:${workspaceFolder}/hi-ml-azure/src:${workspaceFolder}/hi-ml-histopathology/src"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ the environment file since it is necessary for the augmentations.
 - ([#196](https://github.com/microsoft/hi-ml/pull/196)) Show current workspace name in error message.
 
 ### Fixed
-
+- ([#267]https://github.com/microsoft/hi-ml/pull/267)) Correct PYTHONPATH for Windows in VS Code settings
 - ([#266]https://github.com/microsoft/hi-ml/pull/266)) Pin jinja2 package to avoid 'No attribute Markup' bug in version 3.1.0
 - ([#246](https://github.com/microsoft/hi-ml/pull/246)) Added tolerance to `test_attentionlayers.py`.
 - ([#198](https://github.com/microsoft/hi-ml/pull/198)) Dependencies for histopathology folder are no longer specified in `test_requirements.txt`, but correctly in the histopathology Conda environment.


### PR DESCRIPTION
PYTHONPATH for windows - multiple entries should be separated with ';' as [described here](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH)