### PR TITLE
ENH: Add dataloader kwargs in tiles data modules, including num_workers

### DIFF
--- a/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILECrck.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILECrck.py
@@ -108,12 +108,15 @@ class DeepSMILECrck(BaseMIL):
 
     def get_data_module(self) -> TilesDataModule:
         image_key = TcgaCrck_TilesDataset.IMAGE_COLUMN
-        transform = Compose(
-            [
+        if self.is_finetune:
+            transform = LoadTilesBatchd(image_key, progress=True)
+            dataloader_kwargs = dict(num_workers=os.cpu_count(), pin_memory=True)
+        else:
+            transform = Compose([
                 LoadTilesBatchd(image_key, progress=True),
-                EncodeTilesBatchd(keys=image_key, encoder=self.encoder, chunk_size=self.encoding_chunk_size)
-            ]
-        )
+                EncodeTilesBatchd(image_key, self.encoder, chunk_size=self.encoding_chunk_size)
+            ])
+            dataloader_kwargs = dict(num_workers=0, pin_memory=False)
         return TcgaCrckTilesDataModule(
             root_path=self.local_datasets[0],
             max_bag_size=self.max_bag_size,
@@ -125,6 +128,7 @@ class DeepSMILECrck(BaseMIL):
             cache_dir=self.cache_dir,
             crossval_count=self.crossval_count,
             crossval_index=self.crossval_index,
+            dataloader_kwargs=dataloader_kwargs,
         )
 
     def get_callbacks(self) -> List[Callback]:

--- a/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILECrck.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILECrck.py
@@ -117,6 +117,7 @@ class DeepSMILECrck(BaseMIL):
                 EncodeTilesBatchd(image_key, self.encoder, chunk_size=self.encoding_chunk_size)
             ])
             dataloader_kwargs = dict(num_workers=0, pin_memory=False)
+
         return TcgaCrckTilesDataModule(
             root_path=self.local_datasets[0],
             max_bag_size=self.max_bag_size,

--- a/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILECrck.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILECrck.py
@@ -17,6 +17,7 @@ import os
 from monai.transforms import Compose
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.callbacks import Callback
+import torch
 
 from health_azure.utils import CheckpointDownloader
 from health_azure import get_workspace
@@ -110,7 +111,8 @@ class DeepSMILECrck(BaseMIL):
         image_key = TcgaCrck_TilesDataset.IMAGE_COLUMN
         if self.is_finetune:
             transform = LoadTilesBatchd(image_key, progress=True)
-            dataloader_kwargs = dict(num_workers=os.cpu_count(), pin_memory=True)
+            workers_per_gpu = os.cpu_count() // torch.cuda.device_count()
+            dataloader_kwargs = dict(num_workers=workers_per_gpu, pin_memory=True)
         else:
             transform = Compose([
                 LoadTilesBatchd(image_key, progress=True),

--- a/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
@@ -106,12 +106,14 @@ class DeepSMILEPanda(BaseMIL):
     def get_data_module(self) -> PandaTilesDataModule:
         image_key = PandaTilesDataset.IMAGE_COLUMN
         if self.is_finetune:
-            transform = Compose([LoadTilesBatchd(image_key, progress=True)])
+            transform = LoadTilesBatchd(image_key, progress=True)
+            dataloader_kwargs = dict(num_workers=os.cpu_count(), pin_memory=True)
         else:
             transform = Compose([
-                                LoadTilesBatchd(image_key, progress=True),
-                                EncodeTilesBatchd(image_key, self.encoder, chunk_size=self.encoding_chunk_size)
-                                ])
+                LoadTilesBatchd(image_key, progress=True),
+                EncodeTilesBatchd(image_key, self.encoder, chunk_size=self.encoding_chunk_size)
+            ])
+            dataloader_kwargs = dict(num_workers=0, pin_memory=False)
 
         return PandaTilesDataModule(
             root_path=self.local_datasets[0],
@@ -124,6 +126,7 @@ class DeepSMILEPanda(BaseMIL):
             cache_dir=self.cache_dir,
             crossval_count=self.crossval_count,
             crossval_index=self.crossval_index,
+            dataloader_kwargs=dataloader_kwargs,
         )
 
     def get_slides_dataset(self) -> PandaDataset:

--- a/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
@@ -9,6 +9,7 @@ import os
 from monai.transforms import Compose
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.callbacks import Callback
+import torch
 
 from health_azure.utils import CheckpointDownloader
 from health_azure.utils import get_workspace, is_running_in_azure_ml
@@ -107,7 +108,8 @@ class DeepSMILEPanda(BaseMIL):
         image_key = PandaTilesDataset.IMAGE_COLUMN
         if self.is_finetune:
             transform = LoadTilesBatchd(image_key, progress=True)
-            dataloader_kwargs = dict(num_workers=os.cpu_count(), pin_memory=True)
+            workers_per_gpu = os.cpu_count() // torch.cuda.device_count()
+            dataloader_kwargs = dict(num_workers=workers_per_gpu, pin_memory=True)
         else:
             transform = Compose([
                 LoadTilesBatchd(image_key, progress=True),

--- a/hi-ml-histopathology/src/histopathology/datamodules/panda_module.py
+++ b/hi-ml-histopathology/src/histopathology/datamodules/panda_module.py
@@ -3,7 +3,7 @@
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
 
-from typing import Any, Tuple
+from typing import Tuple
 
 from health_ml.utils.split_dataset import DatasetSplits
 

--- a/hi-ml-histopathology/src/histopathology/datamodules/panda_module.py
+++ b/hi-ml-histopathology/src/histopathology/datamodules/panda_module.py
@@ -16,9 +16,6 @@ class PandaTilesDataModule(TilesDataModule):
     Method get_splits() returns the train, val, test splits from the PANDA dataset
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
     def get_splits(self) -> Tuple[PandaTilesDataset, PandaTilesDataset, PandaTilesDataset]:
         dataset = PandaTilesDataset(self.root_path)
         splits = DatasetSplits.from_proportions(dataset.dataset_df.reset_index(),

--- a/hi-ml-histopathology/src/histopathology/datamodules/tcga_crck_module.py
+++ b/hi-ml-histopathology/src/histopathology/datamodules/tcga_crck_module.py
@@ -3,7 +3,7 @@
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
 
-from typing import Tuple, Any
+from typing import Tuple
 
 from health_ml.utils.split_dataset import DatasetSplits
 
@@ -14,9 +14,6 @@ from histopathology.datasets.tcga_crck_tiles_dataset import TcgaCrck_TilesDatase
 class TcgaCrckTilesDataModule(TilesDataModule):
     """ TcgaCrckTilesDataModule is the child class of TilesDataModule specific to TCGA-Crck dataset
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
     def get_splits(self) -> Tuple[TcgaCrck_TilesDataset, TcgaCrck_TilesDataset, TcgaCrck_TilesDataset]:
         """


### PR DESCRIPTION
Enables passing keyword arguments to the dataloaders returned by a `TilesDataModule`. With this, we can now customise settings like `num_workers`, which massively accelerates experiments without caching (e.g. fine-tuning runs).

Note that `num_workers > 0` does not work if the encoder forward pass happens in the dataloader workers (i.e. how we currently do feature caching), as this is only allowed in the main process (or DDP processes).

<!--
## Guidelines

Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:

- Ensure that your PR is small, and implements one change
- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/CONTRIBUTING.md))
- Link the correct GitHub issue for tracking
- Add unit tests for all functions that you introduced or modified
- Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder

## Change the default merge message

When completing your PR, you will be asked for a title and an optional extended description. By default, the extended description will be a concatenation of the individual
commit messages. Please DELETE/REPLACE that with a human readable extended description for non-trivial PRs.
-->
