### PR TITLE
BUG: Conda environment file merging should also split on semicolons

### DIFF
--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -907,9 +907,7 @@ def _split_dependency(dep_str: str) -> Tuple[str, ...]:
     parts: List[str] = re.split('(<=|==|=|>=|<|>|;)', dep_str)
     if len(parts) == 1:
         return (parts[0].strip(), "", "")
-    if len(parts) == 3:
-        return tuple(p.strip() for p in parts)
-    if len(parts) > 3:
+    if len(parts) >= 3:
         return tuple(p.strip() for p in parts)
     raise ValueError(f"Unable to split this package string: {dep_str}")
 

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -904,10 +904,12 @@ def _split_dependency(dep_str: str) -> Tuple[str, ...]:
     :param dep_str: A pip constraint string, like "package-name>=1.0.1"
     :return: A tuple of [package name, operator, version]
     """
-    parts: List[str] = re.split('(<=|==|=|>=|<|>)', dep_str)
+    parts: List[str] = re.split('(<=|==|=|>=|<|>|;)', dep_str)
     if len(parts) == 1:
         return (parts[0].strip(), "", "")
     if len(parts) == 3:
+        return tuple(p.strip() for p in parts)
+    if len(parts) > 3:
         return tuple(p.strip() for p in parts)
     raise ValueError(f"Unable to split this package string: {dep_str}")
 
@@ -931,10 +933,11 @@ class PackageDependency:
         self.package_name = parts[0]
         self.operator = parts[1]
         self.version = parts[2]
+        self.suffix = ''.join(parts[3:]) if len(parts) > 3 else ""
 
     def name_operator_version_str(self) -> str:
         """Concatenate the stored package name, operator and version and return it"""
-        return f"{self.package_name}{self.operator}{self.version}"
+        return f"{self.package_name}{self.operator}{self.version}{self.suffix}"
 
 
 class PinnedOperator(Enum):

--- a/hi-ml-azure/testazure/testazure/test_azure_util.py
+++ b/hi-ml-azure/testazure/testazure/test_azure_util.py
@@ -351,7 +351,7 @@ def test_retrieve_unique_pip_deps() -> None:
                             "git+https:www.github.com/something.git",
                             "foo=1.0; platform_system='Linux'"]
     dedup_deps = util._retrieve_unique_deps(deps_with_one_pinned, pin_pip_operator)  # type: ignore
-    assert dedup_deps == [d.strip() for d in deps_with_one_pinned]
+    assert dedup_deps == [d.replace(" ","") for d in deps_with_one_pinned]
 
     # if duplicates are found with more than one pinned, a ValueError should be raised
     deps_with_duplicates = ["package==1.0", "package==1.1", "git+https:www.github.com/something.git"]

--- a/hi-ml-azure/testazure/testazure/test_azure_util.py
+++ b/hi-ml-azure/testazure/testazure/test_azure_util.py
@@ -261,12 +261,14 @@ def test_split_dependency() -> None:
     assert util._split_dependency("foo.bar>=1.0") == ("foo.bar", ">=", "1.0")
     assert util._split_dependency("foo.bar<=1.0") == ("foo.bar", "<=", "1.0")
     assert util._split_dependency("foo.bar=1.0") == ("foo.bar", "=", "1.0")
+    assert util._split_dependency("foo=1.0; platform_system=='Linux'") ==\
+           ("foo", "=", "1.0", ";", "platform_system", "==", "'Linux'")
 
 
 @pytest.fixture
 def dummy_pip_dep_list_one_pinned() -> List[PackageDependency]:
     return [PackageDependency("a==0.1"), PackageDependency("a>=0.2"), PackageDependency("a=0.3"),
-            PackageDependency("a")]
+            PackageDependency("a=0.4; platform_system='Linux'"), PackageDependency("a")]
 
 
 @pytest.fixture
@@ -345,9 +347,11 @@ def test_resolve_pip_dependencies(dummy_pip_dep_list_one_pinned: List[PackageDep
 def test_retrieve_unique_pip_deps() -> None:
     pin_pip_operator = util.PinnedOperator.PIP
     # if one pinned package is found, that should be retained
-    deps_with_one_pinned = ["package==1.0", "git+https:www.github.com/something.git"]
+    deps_with_one_pinned = ["package==1.0",
+                            "git+https:www.github.com/something.git",
+                            "foo=1.0; platform_system='Linux'"]
     dedup_deps = util._retrieve_unique_deps(deps_with_one_pinned, pin_pip_operator)  # type: ignore
-    assert dedup_deps == deps_with_one_pinned
+    assert dedup_deps == [d.strip() for d in deps_with_one_pinned]
 
     # if duplicates are found with more than one pinned, a ValueError should be raised
     deps_with_duplicates = ["package==1.0", "package==1.1", "git+https:www.github.com/something.git"]

--- a/hi-ml-azure/testazure/testazure/test_azure_util.py
+++ b/hi-ml-azure/testazure/testazure/test_azure_util.py
@@ -350,7 +350,7 @@ def test_retrieve_unique_pip_deps() -> None:
                             "git+https:www.github.com/something.git",
                             "foo=1.0; platform_system='Linux'"]
     dedup_deps = util._retrieve_unique_deps(deps_with_one_pinned, pin_pip_operator)  # type: ignore
-    assert dedup_deps == [d.replace(" ","") for d in deps_with_one_pinned]
+    assert dedup_deps == [d.replace(" ", "") for d in deps_with_one_pinned]
 
     # if duplicates are found with more than one pinned, a ValueError should be raised
     deps_with_duplicates = ["package==1.0", "package==1.1", "git+https:www.github.com/something.git"]


### PR DESCRIPTION
When merging conda environments, we should also split on semicolons (and retain the text after the semicolon) as in the case ```package_name==version; platform_system=="Linux"```. Here we add the code to handle that case.

Resolves [this issue](https://github.com/microsoft/hi-ml/issues/269)