### PR TITLE
BUG: Hotfix for breaking changes in Pytorch Lightning 1.6.0

### DIFF
--- a/hi-ml/run_requirements.txt
+++ b/hi-ml/run_requirements.txt
@@ -4,7 +4,7 @@ jinja2==3.0.2
 matplotlib>=3.4.3
 opencv-python-headless>=4.5.1.48
 pandas>=1.3.4
-pytorch-lightning>=1.5.5
+pytorch-lightning==1.5.5
 rpdb>=0.1.6
 torchvision>=0.11.1
 torch>=1.10.0


### PR DESCRIPTION
PR build breaks as of today with the release of Lightnig 1.6.0. Pin the version as a hotfix.
