### PR TITLE
BUG: Workaround to avoid saving a dataframe as a hyperparameter

### DIFF
--- a/hi-ml-histopathology/src/histopathology/configs/classification/BaseMIL.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/BaseMIL.py
@@ -164,11 +164,7 @@ class BaseMIL(LightningContainer):
                                        class_names=self.class_names,
                                        outputs_handler=outputs_handler
                                        )
-        # WARNING: We set slides_dataset out of the constructor so that it's not saved as a hyperparameter.
-        # slides_datasets (if exists, e.g. in the PANDA cohort) has a dataframe attribute that is not saveable by
-        # pytorch lightning. It shouldn't be passed to the constructor to not include it in the hyperparameters of the
-        # LightningModule and therefore try to dump it by self.save_hyperparameters() in deepmil_module.
-        deepmil_module.outputs_handler.slides_dataset = self.get_slides_dataset()
+        deepmil_module.outputs_handler.set_slides_dataset(self.get_slides_dataset())
         return deepmil_module
 
     def get_data_module(self) -> TilesDataModule:

--- a/hi-ml-histopathology/src/histopathology/configs/classification/BaseMIL.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/BaseMIL.py
@@ -147,24 +147,29 @@ class BaseMIL(LightningContainer):
                                                 n_classes=self.data_module.train_dataset.N_CLASSES,
                                                 tile_size=self.tile_size,
                                                 level=1,
-                                                slides_dataset=self.get_slides_dataset(),
                                                 class_names=self.class_names,
                                                 primary_val_metric=MetricsKey.AUROC,
                                                 maximise=True)
-
-        return DeepMILModule(encoder=self.model_encoder,
-                             label_column=self.data_module.train_dataset.LABEL_COLUMN,
-                             n_classes=self.data_module.train_dataset.N_CLASSES,
-                             pooling_layer=pooling_layer,
-                             num_features=num_features,
-                             dropout_rate=self.dropout_rate,
-                             class_weights=self.data_module.class_weights,
-                             l_rate=self.l_rate,
-                             weight_decay=self.weight_decay,
-                             adam_betas=self.adam_betas,
-                             is_finetune=self.is_finetune,
-                             class_names=self.class_names,
-                             outputs_handler=outputs_handler)
+        deepmil_module = DeepMILModule(encoder=self.model_encoder,
+                                       label_column=self.data_module.train_dataset.LABEL_COLUMN,
+                                       n_classes=self.data_module.train_dataset.N_CLASSES,
+                                       pooling_layer=pooling_layer,
+                                       num_features=num_features,
+                                       dropout_rate=self.dropout_rate,
+                                       class_weights=self.data_module.class_weights,
+                                       l_rate=self.l_rate,
+                                       weight_decay=self.weight_decay,
+                                       adam_betas=self.adam_betas,
+                                       is_finetune=self.is_finetune,
+                                       class_names=self.class_names,
+                                       outputs_handler=outputs_handler
+                                       )
+        # WARNING: We set slides_dataset out of the constructor so that it's not saved as a hyperparameter.
+        # slides_datasets (if exists, e.g. in the PANDA cohort) has a dataframe attribute that is not saveable by
+        # pytorch lightning. It shouldn't be passed to the constructor to not include it in the hyperparameters of the
+        # LightningModule and therefore try to dump it by self.save_hyperparameters() in deepmil_module.
+        deepmil_module.outputs_handler.slides_dataset = self.get_slides_dataset()
+        return deepmil_module
 
     def get_data_module(self) -> TilesDataModule:
         raise NotImplementedError

--- a/hi-ml-histopathology/src/histopathology/utils/output_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/output_utils.py
@@ -351,7 +351,7 @@ class DeepMILOutputsHandler:
     def test_outputs_dir(self) -> Path:
         return self.outputs_root / "test"
 
-    def set_slides_dataset(self, slides_dataset):
+    def set_slides_dataset(self, slides_dataset: SlidesDataset):
         self.slides_dataset = slides_dataset
 
     def _save_outputs(self, epoch_results: EpochResultsType, outputs_dir: Path) -> None:

--- a/hi-ml-histopathology/src/histopathology/utils/output_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/output_utils.py
@@ -351,7 +351,7 @@ class DeepMILOutputsHandler:
     def test_outputs_dir(self) -> Path:
         return self.outputs_root / "test"
 
-    def set_slides_dataset(self, slides_dataset: SlidesDataset):
+    def set_slides_dataset(self, slides_dataset: SlidesDataset) -> None:
         self.slides_dataset = slides_dataset
 
     def _save_outputs(self, epoch_results: EpochResultsType, outputs_dir: Path) -> None:

--- a/hi-ml-histopathology/src/histopathology/utils/output_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/output_utils.py
@@ -316,13 +316,12 @@ class DeepMILOutputsHandler:
 
     def __init__(self, outputs_root: Path, n_classes: int, tile_size: int, level: int,
                  class_names: Optional[Sequence[str]], primary_val_metric: MetricsKey,
-                 maximise: bool, slides_dataset: Optional[SlidesDataset] = None) -> None:
+                 maximise: bool) -> None:
         """
         :param outputs_root: Root directory where to save all produced outputs.
         :param n_classes: Number of MIL classes (set `n_classes=1` for binary).
         :param tile_size: The size of each tile.
         :param level: The downsampling level (e.g. 0, 1, 2) of the tiles if available (default=1).
-        :param slides_dataset: Optional slides dataset from which to plot thumbnails and heatmaps (default=None).
         :param class_names: List of class names. For binary (`n_classes == 1`), expects `len(class_names) == 2`.
             If `None`, will return `('0', '1', ...)`.
         :param primary_val_metric: Name of the validation metric to track for saving best epoch outputs.
@@ -333,7 +332,7 @@ class DeepMILOutputsHandler:
         self.n_classes = n_classes
         self.tile_size = tile_size
         self.level = level
-        self.slides_dataset = slides_dataset
+        self.slides_dataset = None
         self.class_names = validate_class_names(class_names, self.n_classes)
 
         self.outputs_policy = OutputsPolicy(outputs_root=outputs_root,
@@ -351,6 +350,9 @@ class DeepMILOutputsHandler:
     @property
     def test_outputs_dir(self) -> Path:
         return self.outputs_root / "test"
+
+    def set_slides_dataset(self, slides_dataset):
+        self.slides_dataset = slides_dataset
 
     def _save_outputs(self, epoch_results: EpochResultsType, outputs_dir: Path) -> None:
         """Trigger the rendering and saving of DeepMIL outputs and figures.

--- a/hi-ml-histopathology/src/histopathology/utils/output_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/output_utils.py
@@ -315,14 +315,14 @@ class DeepMILOutputsHandler:
     """Class that manages writing validation and test outputs for DeepMIL models."""
 
     def __init__(self, outputs_root: Path, n_classes: int, tile_size: int, level: int,
-                 slides_dataset: Optional[SlidesDataset], class_names: Optional[Sequence[str]],
-                 primary_val_metric: MetricsKey, maximise: bool) -> None:
+                 class_names: Optional[Sequence[str]], primary_val_metric: MetricsKey,
+                 maximise: bool, slides_dataset: Optional[SlidesDataset] = None) -> None:
         """
         :param outputs_root: Root directory where to save all produced outputs.
         :param n_classes: Number of MIL classes (set `n_classes=1` for binary).
         :param tile_size: The size of each tile.
         :param level: The downsampling level (e.g. 0, 1, 2) of the tiles if available (default=1).
-        :param slides_dataset: Optional slides dataset from which to plot thumbnails and heatmaps.
+        :param slides_dataset: Optional slides dataset from which to plot thumbnails and heatmaps (default=None).
         :param class_names: List of class names. For binary (`n_classes == 1`), expects `len(class_names) == 2`.
             If `None`, will return `('0', '1', ...)`.
         :param primary_val_metric: Name of the validation metric to track for saving best epoch outputs.

--- a/hi-ml-histopathology/testhisto/testhisto/utils/test_output_utils.py
+++ b/hi-ml-histopathology/testhisto/testhisto/utils/test_output_utils.py
@@ -31,7 +31,6 @@ def _create_outputs_handler(outputs_root: Path) -> DeepMILOutputsHandler:
         n_classes=1,
         tile_size=224,
         level=1,
-        slides_dataset=None,
         class_names=None,
         primary_val_metric=_PRIMARY_METRIC_KEY,
         maximise=True,


### PR DESCRIPTION
This is a bug fix for the error raised when trying to save slides_dataset as a hyperparameter by deepmil lightning module. The slides_dataset should be set out of the constructor.
