### PR TITLE
ENH: Enable overriding ExperimentConfig parameters from container

### DIFF
--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -147,6 +147,9 @@ class Runner:
         apply_overrides(container, parser2_result.overrides)  # type: ignore
         container.validate()
 
+        # Allow overriding ExperimentConfig params from within the container
+        container.update_experiment_config(experiment_config)
+
         self.lightning_container = container
 
         return parser2_result


### PR DESCRIPTION
In a similar spirit to https://github.com/microsoft/InnerEye-DeepLearning/pull/589, this PR enables overriding `ExperimentConfig` parameters (e.g. `mount_in_azureml`, `cluster`, `num_nodes`, etc.) from a `LightningContainer`. The `update_experiment_config()` method already existed, but was currently not being called by the hi-ml runner.

<!--
## Guidelines

Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:

- Ensure that your PR is small, and implements one change
- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/CONTRIBUTING.md))
- Link the correct GitHub issue for tracking
- Add unit tests for all functions that you introduced or modified
- Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder

## Change the default merge message

When completing your PR, you will be asked for a title and an optional extended description. By default, the extended description will be a concatenation of the individual
commit messages. Please DELETE/REPLACE that with a human readable extended description for non-trivial PRs.
-->
