### PR TITLE
BUG: Mitigate DeepMIL GPU memory leak in results dict

### DIFF
--- a/hi-ml-histopathology/src/histopathology/models/deepmil.py
+++ b/hi-ml-histopathology/src/histopathology/models/deepmil.py
@@ -235,8 +235,7 @@ class DeepMILModule(LightningModule):
                         ResultsKey.CLASS_PROBS: probs_perclass,
                         ResultsKey.PRED_LABEL: predicted_labels,
                         ResultsKey.TRUE_LABEL: bag_labels,
-                        ResultsKey.BAG_ATTN: bag_attn_list,
-                        ResultsKey.IMAGE: batch[TilesDataset.IMAGE_COLUMN]})
+                        ResultsKey.BAG_ATTN: bag_attn_list})
 
         if (TilesDataset.TILE_X_COLUMN in batch.keys()) and (TilesDataset.TILE_Y_COLUMN in batch.keys()):
             results.update({ResultsKey.TILE_X: batch[TilesDataset.TILE_X_COLUMN],

--- a/hi-ml-histopathology/src/histopathology/utils/naming.py
+++ b/hi-ml-histopathology/src/histopathology/utils/naming.py
@@ -44,7 +44,7 @@ class TileKey(str, Enum):
 class ResultsKey(str, Enum):
     SLIDE_ID = 'slide_id'
     TILE_ID = 'tile_id'
-    IMAGE = 'image'
+    FEATURES = 'features'
     IMAGE_PATH = 'image_path'
     LOSS = 'loss'
     PROB = 'prob'

--- a/hi-ml-histopathology/src/histopathology/utils/output_utils.py
+++ b/hi-ml-histopathology/src/histopathology/utils/output_utils.py
@@ -112,14 +112,14 @@ def collate_results(epoch_results: EpochResultsType) -> ResultsType:
     return results
 
 
-def save_outputs_and_features(results: ResultsType, outputs_dir: Path) -> None:
+def save_outputs_csv(results: ResultsType, outputs_dir: Path) -> None:
     print("Saving outputs ...")
     # collate at slide level
     list_slide_dicts = []
     # any column can be used here, the assumption is that the first dimension is the N of slides
     for slide_idx in range(len(results[ResultsKey.SLIDE_ID])):
         slide_dict = {key: results[key][slide_idx] for key in results
-                      if key not in [ResultsKey.IMAGE, ResultsKey.LOSS]}
+                      if key not in [ResultsKey.FEATURES, ResultsKey.LOSS]}
         list_slide_dicts.append(slide_dict)
 
     assert outputs_dir.is_dir(), f"No such dir: {outputs_dir}"
@@ -137,7 +137,7 @@ def save_outputs_and_features(results: ResultsType, outputs_dir: Path) -> None:
 
 def save_features(results: ResultsType, outputs_dir: Path) -> None:
     # Collect all features in a list and save
-    features_list = [features.squeeze(0).cpu() for features in results[ResultsKey.IMAGE]]
+    features_list = [features.squeeze(0).cpu() for features in results[ResultsKey.FEATURES]]
     torch.save(features_list, outputs_dir / 'test_encoded_features.pickle')
 
 
@@ -383,7 +383,7 @@ class DeepMILOutputsHandler:
         outputs_dir.mkdir(exist_ok=True, parents=True)
         figures_dir.mkdir(exist_ok=True, parents=True)
 
-        save_outputs_and_features(results, outputs_dir)
+        save_outputs_csv(results, outputs_dir)
 
         print("Selecting tiles ...")
         selected_slide_ids = save_top_and_bottom_tiles(results, n_classes=self.n_classes, figures_dir=figures_dir)


### PR DESCRIPTION
We've identified a memory leak in `DeepMILModule._shared_step()`: the `results` dictionary contains several GPU tensors. Lightning accumulates references to all outputs of each `training/validation/test_step()`, to be passed into `training/validation/test_epoch_end()`. This means the GPU memory is only freed at the end of an epoch.

The main issue that has been causing many CUDA out-of-memory errors is that, when fine-tuning, `results[ResultsKey.IMAGE]` holds a reference to the input image tensor, meaning throughout an epoch we'd be accumulating the entire dataset in GPU memory.

This PR mitigates this issue by simply removing the problematic tensor from the `results` dictionary, as this data is currently not used in our workflows.

<!--
## Guidelines

Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:

- Ensure that your PR is small, and implements one change
- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/CONTRIBUTING.md))
- Link the correct GitHub issue for tracking
- Add unit tests for all functions that you introduced or modified
- Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder

## Change the default merge message

When completing your PR, you will be asked for a title and an optional extended description. By default, the extended description will be a concatenation of the individual
commit messages. Please DELETE/REPLACE that with a human readable extended description for non-trivial PRs.
-->
