### PR TITLE
BUG: Fix SSL encoder setup and pin versions to support A100 GPUs

### DIFF
--- a/hi-ml-histopathology/environment.yml
+++ b/hi-ml-histopathology/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - cudatoolkit=11.3.1
   - pip=20.1.1
   - python=3.7.3
+  - pytorch=1.10.0
   - python-blosc=1.7.0
   - pip:
       # Run requirements for hi-ml

--- a/hi-ml-histopathology/environment.yml
+++ b/hi-ml-histopathology/environment.yml
@@ -7,9 +7,7 @@ dependencies:
   - cudatoolkit=11.3.1
   - pip=20.1.1
   - python=3.7.3
-  - pytorch=1.10.0
   - python-blosc=1.7.0
-  - torchvision=0.11.1
   - pip:
       # Run requirements for hi-ml
       - dataclasses-json==0.5.2
@@ -55,7 +53,9 @@ dependencies:
       - stopit==1.1.2
       - tabulate==0.8.7
       - tifffile==2021.11.2
+      - torch==1.10.0
       - torchmetrics==0.6.0
+      - torchvision==0.11.1
       - types-python-dateutil==2.8.9
       - umap-learn==0.5.2
       - yacs==0.1.8

--- a/hi-ml-histopathology/src/histopathology/models/encoders.py
+++ b/hi-ml-histopathology/src/histopathology/models/encoders.py
@@ -77,9 +77,9 @@ class ImageNetEncoder(TileEncoder):
     def _get_preprocessing(self) -> Callable:
         return get_imagenet_preprocessing()
 
-    def _get_encoder(self) -> Tuple[Callable, int]:
+    def _get_encoder(self) -> Tuple[torch.nn.Module, int]:
         pretrained_model = self.create_feature_extractor_fn(pretrained=True)
-        return setup_feature_extractor(pretrained_model, self.input_dim)  # type: ignore
+        return setup_feature_extractor(pretrained_model, self.input_dim)
 
 
 class ImageNetSimCLREncoder(TileEncoder):
@@ -116,14 +116,7 @@ class SSLEncoder(TileEncoder):
             freeze_encoder=True,
             pl_checkpoint_path=str(self.pl_checkpoint_path)
         )
-        encoder = model.encoder  # type: ignore
-        for param in encoder.parameters():
-            param.requires_grad = False  # freeze_encoder does not disable gradients
-
-        classifier_head = model.classifier_head
-        embedding_dim = classifier_head.n_input  # type: ignore
-
-        return encoder, embedding_dim
+        return setup_feature_extractor(model.encoder, self.input_dim)
 
 
 class HistoSSLEncoder(TileEncoder):
@@ -137,7 +130,7 @@ class HistoSSLEncoder(TileEncoder):
     WEIGHTS_URL = ("https://github.com/ozanciga/self-supervised-histopathology/releases/"
                    "download/tenpercent/tenpercent_resnet18.ckpt")
 
-    def _get_encoder(self) -> Tuple[Callable, int]:
+    def _get_encoder(self) -> Tuple[torch.nn.Module, int]:
         resnet18_model = resnet18(pretrained=False)
         histossl_encoder = load_weights_to_model(self.WEIGHTS_URL, resnet18_model)
-        return setup_feature_extractor(histossl_encoder, self.input_dim)  # type: ignore
+        return setup_feature_extractor(histossl_encoder, self.input_dim)

--- a/hi-ml/run_requirements.txt
+++ b/hi-ml/run_requirements.txt
@@ -6,5 +6,5 @@ opencv-python-headless>=4.5.1.48
 pandas>=1.3.4
 pytorch-lightning==1.5.5
 rpdb>=0.1.6
-torchvision==0.11.1
-torch==1.10.0
+torchvision>=0.11.1
+torch>=1.10.0

--- a/hi-ml/run_requirements.txt
+++ b/hi-ml/run_requirements.txt
@@ -6,5 +6,5 @@ opencv-python-headless>=4.5.1.48
 pandas>=1.3.4
 pytorch-lightning==1.5.5
 rpdb>=0.1.6
-torchvision>=0.11.1
-torch>=1.10.0
+torchvision==0.11.1
+torch==1.10.0


### PR DESCRIPTION
To enable DeepMIL fine-tuning experiments, this PR addresses two issues:
* Fix the setup of `SSLEncoder` to ensure there are no unused parameters (which breaks DDP);
* Pin `torch=1.10` to ensure compatibility with A100 GPUs (this was being overridden to 1.11 by the `torch>=10` in `hi-ml/run_requirements.txt`).

<!--
## Guidelines

Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:

- Ensure that your PR is small, and implements one change
- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/CONTRIBUTING.md))
- Link the correct GitHub issue for tracking
- Add unit tests for all functions that you introduced or modified
- Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder

## Change the default merge message

When completing your PR, you will be asked for a title and an optional extended description. By default, the extended description will be a concatenation of the individual
commit messages. Please DELETE/REPLACE that with a human readable extended description for non-trivial PRs.
-->
