### PR TITLE
BUG: Pin torchvision to install alongside PyTorch and CUDA toolkit

### DIFF
--- a/hi-ml-histopathology/environment.yml
+++ b/hi-ml-histopathology/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - python=3.7.3
   - pytorch=1.10.0
   - python-blosc=1.7.0
+  - torchvision=0.11.1
   - pip:
       # Run requirements for hi-ml
       - dataclasses-json==0.5.2


### PR DESCRIPTION
Fixes an issue whereby `torchvision` gets installed by `pip` with the wrong `cudatoolkit` version. With this change, `pytorch`, `torchvision`, and `cudatoolkit` get installed at the same time by `conda`.

<!--
## Guidelines

Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:

- Ensure that your PR is small, and implements one change
- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/CONTRIBUTING.md))
- Link the correct GitHub issue for tracking
- Add unit tests for all functions that you introduced or modified
- Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder

## Change the default merge message

When completing your PR, you will be asked for a title and an optional extended description. By default, the extended description will be a concatenation of the individual
commit messages. Please DELETE/REPLACE that with a human readable extended description for non-trivial PRs.
-->
