### PR TITLE
ENH: Add flag pl_limit_test_batches

### DIFF
--- a/hi-ml/src/health_ml/deep_learning_config.py
+++ b/hi-ml/src/health_ml/deep_learning_config.py
@@ -401,6 +401,10 @@ class TrainerParams(param.Parameterized):
         param.Number(default=None,
                      doc="PyTorch Lightning trainer flag 'limit_val_batches': Limit the validation dataset to the "
                          "given number of batches if integer, or proportion of validation dataset if float.")
+    pl_limit_test_batches: Optional[IntOrFloat] = \
+        param.Number(default=None,
+                     doc="PyTorch Lightning trainer flag 'limit_test_batches': Limit the test dataset to the "
+                         "given number of batches if integer, or proportion of test dataset if float.")
     pl_profiler: Optional[str] = \
         param.String(default=None,
                      doc="The value to use for the 'profiler' argument for the Lightning trainer. "

--- a/hi-ml/src/health_ml/model_trainer.py
+++ b/hi-ml/src/health_ml/model_trainer.py
@@ -145,10 +145,12 @@ def create_lightning_trainer(container: LightningContainer,
                       accelerator=accelerator,
                       strategy=strategy,
                       max_epochs=container.max_epochs,
-                      # Both these arguments can be integers or floats. If integers, it is the number of batches.
+                      # All of the following limit_batches  arguments can be integers or floats.
+                      # If integers, it is the number of batches.
                       # If float, it's the fraction of batches. We default to 1.0 (processing all batches).
                       limit_train_batches=container.pl_limit_train_batches or 1.0,
                       limit_val_batches=container.pl_limit_val_batches or 1.0,
+                      limit_test_batches=container.pl_limit_test_batches or 1.0,
                       num_sanity_val_steps=container.pl_num_sanity_val_steps,
                       # check_val_every_n_epoch=container.pl_check_val_every_n_epoch,
                       callbacks=callbacks,

--- a/hi-ml/testhiml/testhiml/test_model_trainer.py
+++ b/hi-ml/testhiml/testhiml/test_model_trainer.py
@@ -103,41 +103,50 @@ def test_create_lightning_trainer_limit_batches() -> None:
     _mock_logger = MagicMock()
     _mock_logger.log.return_value = None
 
-    # first create a trainer and check what the default number of train batches is
+    # First create a trainer and check what the default number of train, val and test batches is
     trainer, _ = create_lightning_trainer(container)
     # We have to call the 'fit' method on the trainer before it updates the number of batches
     with patch.object(trainer, "logger", new=_mock_logger):
         trainer.fit(lightning_model, data_module)
     original_num_train_batches = trainer.num_training_batches
     original_num_val_batches = trainer.num_val_batches[0]
+    original_num_test_batches = trainer.num_test_batches
 
     # Now try to limit the number of batches to an integer number
     limit_train_batches_int = random.randint(1, 10)
     limit_val_batches_int = random.randint(1, 10)
+    limit_test_batches_int = random.randint(1, 10)
     container.pl_limit_train_batches = limit_train_batches_int
     container.pl_limit_val_batches = limit_val_batches_int
+    container.pl_limit_test_batches = limit_test_batches_int
 
     trainer2, _ = create_lightning_trainer(container)
     assert trainer2.limit_train_batches == limit_train_batches_int
     assert trainer2.limit_val_batches == limit_val_batches_int
+    assert trainer2.limit_test_batches == limit_test_batches_int
     with patch.object(trainer2, "logger", new=_mock_logger):
         trainer2.fit(lightning_model, data_module)
     assert trainer2.num_training_batches == limit_train_batches_int
     assert trainer2.num_val_batches[0] == limit_val_batches_int
+    assert trainer2.num_test_batches == limit_test_batches_int
 
-    # try to limit the number of batches with float number (i.e. proportion of full data)
+    # Try to limit the number of batches with float number (i.e. proportion of full data)
     limit_train_batches_float = random.uniform(0.1, 1.0)
     limit_val_batches_float = random.uniform(0.1, 1.0)
+    limit_test_batches_float = random.uniform(0.1, 1.0)
     container.pl_limit_train_batches = limit_train_batches_float
     container.pl_limit_val_batches = limit_val_batches_float
+    container.pl_limit_test_batches = limit_test_batches_float
     trainer3, _ = create_lightning_trainer(container)
     assert trainer3.limit_train_batches == limit_train_batches_float
     assert trainer3.limit_val_batches == limit_val_batches_float
     with patch.object(trainer3, "logger", new=_mock_logger):
         trainer3.fit(lightning_model, data_module)
+
     # The number of batches should be a proportion of the full available set
     assert trainer3.num_training_batches == floor(limit_train_batches_float * original_num_train_batches)
     assert trainer3.num_val_batches[0] == floor(limit_val_batches_float * original_num_val_batches)
+    assert trainer3.num_test_batches[0] == floor(limit_test_batches_float * original_num_test_batches)
 
 
 def test_model_train() -> None:


### PR DESCRIPTION
- Add flag `--pl_limit_test_batches` to limit the number of test batches (similar to our current flags `--pl_limit_train_batches` and `--pl_limit_val_batches`
- Update `test_create_lightning_trainer_limit_batches` to include limiting test batches