### PR TITLE
STYLE: Rename panda_tiles to panda_tiles_small

### DIFF
--- a/hi-ml/other/image_loading/profile_image_loading.py
+++ b/hi-ml/other/image_loading/profile_image_loading.py
@@ -337,7 +337,7 @@ def mount_and_convert_source_files(
     :param bin_libs: List of subfolder names, file suffix, and write/read functions for tensor/array options.
     :return: None.
     """
-    with dataset.mount("/tmp/datasets/panda_tiles") as mount_context:
+    with dataset.mount("/tmp/datasets/panda_tiles_small") as mount_context:
         input_folder = Path(mount_context.mount_point)
 
         for option, greyscale, crop in source_options:
@@ -458,7 +458,7 @@ def wrap_run_profiling(
 
 def main() -> None:
     """
-    Mount a dataset called 'panda_tiles', assumed to contain image files, with file extension png. Load each png file,
+    Mount a dataset called 'panda_tiles_small', assumed to contain image files, with file extension png. Load each png file,
     convert to greyscale, and save to a separate folder.
 
     :return: None.
@@ -497,7 +497,7 @@ def main() -> None:
 
     dataset = get_or_create_dataset(workspace=workspace,
                                     datastore_name='himldatasets',
-                                    dataset_name='panda_tiles')
+                                    dataset_name='panda_tiles_small')
 
     output_folder = Path("outputs")
     output_folder.mkdir(exist_ok=True)

--- a/hi-ml/other/image_loading/profile_image_loading.py
+++ b/hi-ml/other/image_loading/profile_image_loading.py
@@ -458,8 +458,8 @@ def wrap_run_profiling(
 
 def main() -> None:
     """
-    Mount a dataset called 'panda_tiles_small', assumed to contain image files, with file extension png. Load each png file,
-    convert to greyscale, and save to a separate folder.
+    Mount a dataset called 'panda_tiles_small', assumed to contain image files, with file extension png.
+    Load each png file, convert to greyscale, and save to a separate folder.
 
     :return: None.
     """


### PR DESCRIPTION
The AML dataset panda_tiles (which is a subset of 61 PANDA_tiles files) will be renamed to panda_tiles_small, in order not to confuse with the full-size PANDA_tiles dataset