### PR TITLE
ENH: Encoding in chunks to enable WSI validation and test

### DIFF
--- a/hi-ml-histopathology/src/histopathology/configs/classification/BaseMIL.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/BaseMIL.py
@@ -288,7 +288,8 @@ class BaseMILTiles(BaseMIL):
                                             adam_betas=self.adam_betas,
                                             is_finetune=self.is_finetune,
                                             class_names=self.class_names,
-                                            outputs_handler=outputs_handler)
+                                            outputs_handler=outputs_handler,
+                                            chunk_size=self.encoding_chunk_size)
         outputs_handler.set_slides_dataset(self.get_slides_dataset())
         return deepmil_module
 


### PR DESCRIPTION
In this PR:
- A parameter `chunk_size` is added to `BaseDeepMILModule`. In `BaseMILTiles`, this is set to `encoding_chunk_size` which is an existing parameter of the container. 
- When `chunk_size`> 0, tiles are encoded in chunks of size `chunk_size`. This can avoid out-of-memory errors for large WSI.
- WSI validation and test is possible by using `max_bag_size_inf=0`.
