### PR TITLE
BUG: Update path to PANDA tiles directory

### DIFF
--- a/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
@@ -31,7 +31,7 @@ class PandaTilesDataset(TilesDataset):
     SPLIT_COLUMN = None  # PANDA does not have an official train/test split
     N_CLASSES = 6
 
-    _RELATIVE_ROOT_FOLDER = Path("PANDA_tiles_20210926-135446/panda_tiles_level1_224")
+    _RELATIVE_ROOT_FOLDER = Path("PANDA_tiles_20220427/panda_tiles_level1_224")
 
     def __init__(self,
                  root: Path,


### PR DESCRIPTION
This is not really a bug, but I couldn't think of a better tag.

Now that

- #311 and
- #321

have been merged, I have generated the new PANDA tiles dataset, which ~is being~ has been copied to our Azure container.
~I will remove the draft status once the transfer is finished.~