### PR TITLE
ENH: Add param 'wait_for_completion' to ExperimentConfig

### DIFF
--- a/hi-ml/src/health_ml/experiment_config.py
+++ b/hi-ml/src/health_ml/experiment_config.py
@@ -19,4 +19,5 @@ class ExperimentConfig(param.Parameterized):
     docker_shm_size: str = param.String("400g",
                                         doc="The shared memory in the Docker image for the AzureML VMs.")
     wait_for_completion: bool = param.Boolean(default=False,
-                                              doc="If True, wait for AML Run to complete before proceeding")
+                                              doc="If True, wait for AML Run to complete before proceeding. "
+                                                  "If False, submit the run to AML and exit")

--- a/hi-ml/src/health_ml/experiment_config.py
+++ b/hi-ml/src/health_ml/experiment_config.py
@@ -18,3 +18,5 @@ class ExperimentConfig(param.Parameterized):
                                                "always be mounted.")
     docker_shm_size: str = param.String("400g",
                                         doc="The shared memory in the Docker image for the AzureML VMs.")
+    wait_for_completion: bool = param.Boolean(default=False,
+                                              doc="If True, wait for AML Run to complete before proceeding")

--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -278,7 +278,7 @@ class Runner:
                     experiment_name=self.lightning_container.model_name,  # create_experiment_name(),
                     input_datasets=input_datasets,  # type: ignore
                     num_nodes=self.experiment_config.num_nodes,
-                    wait_for_completion=False,
+                    wait_for_completion=self.experiment_config.wait_for_completion,
                     ignored_folders=[],
                     submit_to_azureml=self.experiment_config.azureml,
                     docker_base_image=DEFAULT_DOCKER_BASE_IMAGE,


### PR DESCRIPTION
Currently we always pass `wait_for_completion=False` to `submit_to_azure`. This change enables the user to override this to `wait_for_completion=True` via the commandline 