### PR TITLE
ENH: Enable selection of primary validation metric in BaseMIL

### DIFF
--- a/hi-ml-histopathology/src/histopathology/configs/classification/BaseMIL.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/BaseMIL.py
@@ -58,8 +58,8 @@ class BaseMIL(LightningContainer):
     primary_val_metric: MetricsKey = param.ClassSelector(default=MetricsKey.AUROC, class_=MetricsKey,
                                                          doc="Primary validation metric to track for checkpointing and "
                                                              "generating outputs.")
-    maximise_primary_metric: bool = param.ClassSelector(True, doc="Whether the primary validation metric should be "
-                                                                  "maximised (otherwise minimised).")
+    maximise_primary_metric: bool = param.Boolean(True, doc="Whether the primary validation metric should be "
+                                                            "maximised (otherwise minimised).")
 
     # Encoder parameters:
     encoder_type: str = param.String(doc="Name of the encoder class to use.")


### PR DESCRIPTION
So far we've hard-coded validation AUROC as the primary metric for checkpointing and saving outputs. This PR adds the option to customise it depending on the experiment (keeping val. AUROC as default for now).

<!--
## Guidelines

Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:

- Ensure that your PR is small, and implements one change
- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/CONTRIBUTING.md))
- Link the correct GitHub issue for tracking
- Add unit tests for all functions that you introduced or modified
- Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder

## Change the default merge message

When completing your PR, you will be asked for a title and an optional extended description. By default, the extended description will be a concatenation of the individual
commit messages. Please DELETE/REPLACE that with a human readable extended description for non-trivial PRs.
-->
