### PR TITLE
BUG: Update get_all_environment_files after environment.yml has moved

### DIFF
--- a/hi-ml-azure/src/health_azure/paths.py
+++ b/hi-ml-azure/src/health_azure/paths.py
@@ -51,7 +51,7 @@ def git_repo_root_folder() -> Path:
 def shared_himl_conda_env_file() -> Path:
     """
     Attempts to return the path to the Conda environment file in the hi-ml project folder. If hi-ml has been
-    installed as a package (instead of as a git submodule or  directly downloadeing the repo) it's not possible
+    installed as a package (instead of as a git submodule or directly downloading the repo) it's not possible
     to find this shared conda file, and so a ValueError will be raised.
 
     :return: Path to the Conda environment file in the hi-ml project folder

--- a/hi-ml-azure/src/health_azure/paths.py
+++ b/hi-ml-azure/src/health_azure/paths.py
@@ -38,25 +38,25 @@ def git_repo_root_folder() -> Path:
     """
     Attempts to return the path to the top-level hi-ml repo that contains the hi-ml and hi-ml-azure packages.
     This top level repo will only be present if hi-ml has been installed as a git submodule, or the repo has
-    been directly downloaded. Otherwise (e.g.if hi-ml has been installed as a pip package) returns None
+    been directly downloaded. Otherwise (e.g.if hi-ml has been installed as a pip package) raises an exception
 
-    :return: Path to the himl root dir if it exists, else None
+    :return: Path to the himl root dir if it exists
     """
     if not is_himl_used_from_git_repo():
-        return None
+        raise ValueError("This function should not be used if hi-ml is used as an installed package.")
     current_file = Path(__file__).resolve()
     return current_file.parent.parent.parent.parent
 
 
 def shared_himl_conda_env_file() -> Path:
     """
-    Attempts to return the path to the Conda environment file in the hi-ml project folder. If hi-ml has been installed as a package (instead of as a git submodule or  directly downloadeing the repo) it's not possible to find this shared conda file, and so a ValueError will be raised.
+    Attempts to return the path to the Conda environment file in the hi-ml project folder. If hi-ml has been
+    installed as a package (instead of as a git submodule or  directly downloadeing the repo) it's not possible
+    to find this shared conda file, and so a ValueError will be raised.
 
     :return: Path to the Conda environment file in the hi-ml project folder
     :raises: ValueError if hi-ml has not been installed/downloaded from the git repo (i.e. we can't get the path to
         the shared environment definition file)
     """
     repo_root_folder = git_repo_root_folder()
-    if repo_root_folder is None:
-         raise ValueError("This function can only be used if the HI-ML package is used directly from the git repo")
     return repo_root_folder / "hi-ml" / ENVIRONMENT_YAML_FILE_NAME

--- a/hi-ml-azure/src/health_azure/paths.py
+++ b/hi-ml-azure/src/health_azure/paths.py
@@ -40,18 +40,23 @@ def git_repo_root_folder() -> Path:
     This top level repo will only be present if hi-ml has been installed as a git submodule, or the repo has
     been directly downloaded. Otherwise (e.g.if hi-ml has been installed as a pip package) returns None
 
-    return: Path to the himl root dir if it exists, else None
+    :return: Path to the himl root dir if it exists, else None
     """
     if not is_himl_used_from_git_repo():
-        raise ValueError("This function can only be used if the HI-ML package is used directly from the git repo.")
+        return None
     current_file = Path(__file__).resolve()
     return current_file.parent.parent.parent.parent
 
 
 def shared_himl_conda_env_file() -> Path:
     """
-    Returns the path to the Conda environment file in the hi-ml project folder.
+    Attempts to return the path to the Conda environment file in the hi-ml project folder. If hi-ml has been installed as a package (instead of as a git submodule or  directly downloadeing the repo) it's not possible to find this shared conda file, and so a ValueError will be raised.
 
     :return: Path to the Conda environment file in the hi-ml project folder
+    :raises: ValueError if hi-ml has not been installed/downloaded from the git repo (i.e. we can't get the path to
+        the shared environment definition file)
     """
-    return git_repo_root_folder() / "hi-ml" / ENVIRONMENT_YAML_FILE_NAME
+    repo_root_folder = git_repo_root_folder()
+    if repo_root_folder is None:
+         raise ValueError("This function can only be used if the HI-ML package is used directly from the git repo")
+    return repo_root_folder / "hi-ml" / ENVIRONMENT_YAML_FILE_NAME

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -693,15 +693,19 @@ def determine_run_id_type(run_or_recovery_id: str) -> str:
     return run_or_recovery_id
 
 
-def find_file_in_parent_folders(file_name: str, stop_at_path: List[Path]) -> Optional[Path]:
+def find_file_in_parent_folders(file_name: str, stop_at_path: List[Path],
+                                start_at_path: Optional[Path] = None) -> Optional[Path]:
     """Searches for a file of the given name in the current working directory, or any of its parent folders.
     Searching stops if either the file is found, or no parent folder can be found, or the search has reached any
     of the given folders in stop_at_path.
 
     :param file_name: The name of the file to find.
     :param stop_at_path: A list of folders. If any of them is reached, search stops.
+    :param start_at_path: An optional path to the directory in which to start searching. If not supplied,
+        will use the current working directory.
     :return: The absolute path of the file if found, or None if it was not found.
     """
+    start_at_path = start_at_path or Path.cwd()
 
     def return_file_or_parent(start_at: Path) -> Optional[Path]:
         logging.debug(f"Searching for file {file_name} in {start_at}")
@@ -712,7 +716,7 @@ def find_file_in_parent_folders(file_name: str, stop_at_path: List[Path]) -> Opt
             return None
         return return_file_or_parent(start_at.parent)
 
-    return return_file_or_parent(start_at=Path.cwd())
+    return return_file_or_parent(start_at=start_at_path)
 
 
 def find_file_in_parent_to_pythonpath(file_name: str) -> Optional[Path]:

--- a/hi-ml-azure/testazure/testazure/test_azure_util.py
+++ b/hi-ml-azure/testazure/testazure/test_azure_util.py
@@ -35,7 +35,7 @@ from health_azure.himl import AML_IGNORE_FILE, append_to_amlignore
 from health_azure.utils import PackageDependency, create_argparser
 from testazure.test_himl import RunTarget, render_and_run_test_script
 from testazure.utils_testazure import (DEFAULT_IGNORE_FOLDERS, DEFAULT_WORKSPACE, MockRun, change_working_directory,
-                                       repository_root)
+                                       himl_azure_root, repository_root)
 
 RUN_ID = uuid4().hex
 RUN_NUMBER = 42
@@ -50,8 +50,52 @@ def oh_no() -> None:
     raise ValueError("Throwing an exception")
 
 
+@pytest.mark.fast()
+def test_find_file_in_parent_folders(caplog: LogCaptureFixture) -> None:
+    current_file_path = Path(__file__)
+    # If no start_at arg is provided, will start looking for file at current working directory.
+    # First mock this to be the hi-ml-azure root
+    himl_az_root = himl_azure_root()
+    himl_azure_test_root = himl_az_root / "testazure" / "testazure"
+    with patch("health_azure.utils.Path.cwd", return_value=himl_azure_test_root):
+        # current_working_directory = Path.cwd()
+        found_file_path = util.find_file_in_parent_folders(
+            file_name=current_file_path.name,
+            stop_at_path=[himl_az_root]
+         )
+        last_caplog_msg = caplog.messages[-1]
+        assert found_file_path == current_file_path
+        assert(f"Searching for file {current_file_path.name} in {himl_azure_test_root}" in last_caplog_msg)
+
+        # Now try to search for a nonexistent path in the same folder. This should return None
+        nonexistent_path = himl_az_root / "idontexist.py"
+        assert not nonexistent_path.is_file()
+        assert  util.find_file_in_parent_folders(
+            file_name=nonexistent_path.name,
+            stop_at_path=[himl_az_root]
+         ) is None
+
+        # Try to find the first path (i.e. current file name) when starting in a different folder.
+        # This should not work
+        assert  util.find_file_in_parent_folders(
+            file_name=current_file_path.name,
+            stop_at_path=[himl_az_root],
+            start_at_path=himl_az_root
+         ) is None
+
+
+    # Try to find the first path (i.e. current file name) when current working directory is not the testazure
+    # folder. This should not work
+    with patch("health_azure.utils.Path.cwd", return_value=himl_az_root):
+        assert not (himl_az_root / current_file_path.name).is_file()
+        assert  util.find_file_in_parent_folders(
+            file_name=current_file_path.name,
+            stop_at_path=[himl_az_root.parent]
+         ) is None
+
+
 @pytest.mark.fast
-def test_find_file(tmp_path: Path) -> None:
+def test_find_file_in_parent_to_pythonpath(tmp_path: Path) -> None:
     file_name = "some_file.json"
     file = tmp_path / file_name
     file.touch()

--- a/hi-ml-azure/testazure/testazure/test_azure_util.py
+++ b/hi-ml-azure/testazure/testazure/test_azure_util.py
@@ -62,7 +62,7 @@ def test_find_file_in_parent_folders(caplog: LogCaptureFixture) -> None:
         found_file_path = util.find_file_in_parent_folders(
             file_name=current_file_path.name,
             stop_at_path=[himl_az_root]
-         )
+        )
         last_caplog_msg = caplog.messages[-1]
         assert found_file_path == current_file_path
         assert(f"Searching for file {current_file_path.name} in {himl_azure_test_root}" in last_caplog_msg)
@@ -70,28 +70,27 @@ def test_find_file_in_parent_folders(caplog: LogCaptureFixture) -> None:
         # Now try to search for a nonexistent path in the same folder. This should return None
         nonexistent_path = himl_az_root / "idontexist.py"
         assert not nonexistent_path.is_file()
-        assert  util.find_file_in_parent_folders(
+        assert util.find_file_in_parent_folders(
             file_name=nonexistent_path.name,
             stop_at_path=[himl_az_root]
-         ) is None
+        ) is None
 
         # Try to find the first path (i.e. current file name) when starting in a different folder.
         # This should not work
-        assert  util.find_file_in_parent_folders(
+        assert util.find_file_in_parent_folders(
             file_name=current_file_path.name,
             stop_at_path=[himl_az_root],
             start_at_path=himl_az_root
-         ) is None
-
+        ) is None
 
     # Try to find the first path (i.e. current file name) when current working directory is not the testazure
     # folder. This should not work
     with patch("health_azure.utils.Path.cwd", return_value=himl_az_root):
         assert not (himl_az_root / current_file_path.name).is_file()
-        assert  util.find_file_in_parent_folders(
+        assert util.find_file_in_parent_folders(
             file_name=current_file_path.name,
             stop_at_path=[himl_az_root.parent]
-         ) is None
+        ) is None
 
 
 @pytest.mark.fast

--- a/hi-ml-azure/testazure/testazure/test_paths.py
+++ b/hi-ml-azure/testazure/testazure/test_paths.py
@@ -1,0 +1,21 @@
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from health_azure.paths import ENVIRONMENT_YAML_FILE_NAME, git_repo_root_folder, shared_himl_conda_env_file
+
+
+def test_git_repo_root_folder() -> None:
+    with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=True):
+        assert git_repo_root_folder() is not None
+    with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=False):
+        assert git_repo_root_folder() is None
+
+
+def test_shared_himl_conda_env_file(tmp_path: Path) -> None:
+    with patch("health_azure.paths.git_repo_root_folder", return_value=tmp_path):
+        assert shared_himl_conda_env_file() == tmp_path / "hi-ml" / ENVIRONMENT_YAML_FILE_NAME
+    with patch("health_azure.paths.git_repo_root_folder", return_value=None):
+        with pytest.raises(ValueError) as e:
+            shared_himl_conda_env_file()
+            assert "can only be used if the HI-ML package is used directly from the git repo" in str(e)

--- a/hi-ml-azure/testazure/testazure/test_paths.py
+++ b/hi-ml-azure/testazure/testazure/test_paths.py
@@ -5,17 +5,21 @@ from unittest.mock import patch
 from health_azure.paths import ENVIRONMENT_YAML_FILE_NAME, git_repo_root_folder, shared_himl_conda_env_file
 
 
+@pytest.mark.fast
 def test_git_repo_root_folder() -> None:
     with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=True):
         assert git_repo_root_folder() is not None
     with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=False):
-        assert git_repo_root_folder() is None
+        with pytest.raises(ValueError) as e:
+            git_repo_root_folder()
+            assert"This function should not be used if hi-ml is used as an installed package." in str(e)
 
 
+@pytest.mark.fast
 def test_shared_himl_conda_env_file(tmp_path: Path) -> None:
     with patch("health_azure.paths.git_repo_root_folder", return_value=tmp_path):
         assert shared_himl_conda_env_file() == tmp_path / "hi-ml" / ENVIRONMENT_YAML_FILE_NAME
-    with patch("health_azure.paths.git_repo_root_folder", return_value=None):
+    with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=False):
         with pytest.raises(ValueError) as e:
             shared_himl_conda_env_file()
-            assert "can only be used if the HI-ML package is used directly from the git repo" in str(e)
+            assert "This function should not be used if hi-ml is used as an installed package" in str(e)

--- a/hi-ml/src/health_ml/utils/common_utils.py
+++ b/hi-ml/src/health_ml/utils/common_utils.py
@@ -259,7 +259,7 @@ def check_conda_environments(env_files: List[Path]) -> None:
     if paths.is_himl_used_from_git_repo():
         repo_root_yaml: Path = paths.shared_himl_conda_env_file()
     else:
-        repo_root_yaml = None
+        repo_root_yaml = None  # type: ignore
     for file in env_files:
         has_pip_include, _ = is_conda_file_with_pip_include(file)
         # PIP include statements are only valid when reading from the repository root YAML file, because we

--- a/hi-ml/src/health_ml/utils/common_utils.py
+++ b/hi-ml/src/health_ml/utils/common_utils.py
@@ -223,7 +223,7 @@ def get_all_environment_files(project_root: Path, additional_files: Optional[Lis
     env_files = []
     if paths.is_himl_used_from_git_repo():
         env_file = paths.shared_himl_conda_env_file()
-        if env_file is None or not env_file.exists():
+        if not env_file.exists():
             # Searching for Conda file starts at current working directory, meaning it might not find
             # the file if cwd is outside the git repo
             env_file = project_root / paths.ENVIRONMENT_YAML_FILE_NAME
@@ -257,9 +257,9 @@ def check_conda_environments(env_files: List[Path]) -> None:
     :param env_files: The list of Conda environment YAML files to check.
     """
     if paths.is_himl_used_from_git_repo():
-        repo_root_yaml: Path = paths.shared_himl_conda_env_file()
+        repo_root_yaml: Optional[Path] = paths.shared_himl_conda_env_file()
     else:
-        repo_root_yaml = None  # type: ignore
+        repo_root_yaml = None
     for file in env_files:
         has_pip_include, _ = is_conda_file_with_pip_include(file)
         # PIP include statements are only valid when reading from the repository root YAML file, because we

--- a/hi-ml/testhiml/testhiml/utils/test_common_utils.py
+++ b/hi-ml/testhiml/testhiml/utils/test_common_utils.py
@@ -2,10 +2,18 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
+from typing import Generator
+import pytest
+from pathlib import Path
 from torch.nn import Module
+from unittest.mock import patch
+
+from health_azure.paths import ENVIRONMENT_YAML_FILE_NAME, git_repo_root_folder, is_himl_used_from_git_repo
 from health_ml.utils import set_model_to_eval_mode
+from health_ml.utils.common_utils import check_conda_environments, get_all_environment_files
 
 
+@pytest.mark.fast
 def test_set_to_eval_mode() -> None:
     model = Module()
     model.train(True)
@@ -19,3 +27,104 @@ def test_set_to_eval_mode() -> None:
     with set_model_to_eval_mode(model):
         assert not model.training
     assert not model.training
+
+
+@pytest.fixture(scope="session")
+def temp_project_root(tmp_path_factory: pytest.TempPathFactory,) -> Generator:
+    temp_project_root = tmp_path_factory.mktemp("test_folder")
+    yield temp_project_root
+
+
+@pytest.fixture(scope="session")
+def temp_env_path(temp_project_root: Path) -> Generator:
+    tmp_env_path = temp_project_root / ENVIRONMENT_YAML_FILE_NAME
+    print(f"TEMP ENV PATH: {tmp_env_path}")
+    tmp_env_path.write_text("name: DummyEnv")
+    yield tmp_env_path
+    tmp_env_path.unlink()
+
+
+@pytest.fixture(scope="session")
+def empty_temp_dir(temp_project_root: Path) -> Generator:
+    # Create a directory that will not contain an environment definition file
+    empty_temp_dir = temp_project_root / "empty"
+    empty_temp_dir.mkdir()
+    yield empty_temp_dir
+
+
+@pytest.mark.fast
+def test_get_all_environment_files(temp_project_root: Path, temp_env_path: Path, empty_temp_dir: Path) -> None:
+    # Firstly check the cases when is_himl_used_from_git_repo returns True
+    with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=True):
+        assert is_himl_used_from_git_repo()
+        # If we don't patch git_repo_root_folder it will return top-level hi-ml folder
+        himl_root = git_repo_root_folder()
+        # Separate workspaces means the environment.yml file is located in 'hi-ml/hi-ml'
+        # As an initial sanity check, ensure this file exists
+        env_file_root = himl_root / "hi-ml"
+        expected_env_path = env_file_root / ENVIRONMENT_YAML_FILE_NAME
+        assert expected_env_path.is_file()
+        # Now check that get_all_environment_files returns this path
+        assert get_all_environment_files(project_root=himl_root) == [expected_env_path]
+
+        # If we patch the git_repo_root_folder to return a different folder, we should be able
+        # to pick up an env file there
+        with patch("health_azure.paths.git_repo_root_folder", return_value=temp_project_root):
+            assert get_all_environment_files(project_root=temp_project_root) == [temp_env_path]
+
+        # If we patch git_repo_root_folder to return a different folder that does not contain an env
+        # file, an error should be raised
+        with patch("health_azure.paths.git_repo_root_folder", return_value=empty_temp_dir):
+            with pytest.raises(AssertionError) as e1:
+                get_all_environment_files(project_root=empty_temp_dir)
+            assert "Didn't find an environment file at" in str(e1)
+
+    # Now check the case where is_himl_used_from_git_repo returns False. In this case, the project root repo
+    # won't be hi-ml, so we replace it here with temp_path (which has no concept of the hi-ml directory)
+    with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=False):
+        with patch("health_azure.paths.git_repo_root_folder", return_value=temp_project_root):
+            assert get_all_environment_files(project_root=temp_project_root) == [temp_env_path]
+
+        # Now pass a directory that doesn't have an env file and check that an error is raised
+        with patch("health_azure.paths.git_repo_root_folder", return_value=empty_temp_dir):
+            with pytest.raises(ValueError) as e2:
+                get_all_environment_files(project_root=empty_temp_dir)
+                assert "No Conda environment files were found in the repository" in str(e2)
+
+
+@pytest.mark.fast
+def test_check_conda_environments(temp_env_path: Path) -> None:
+    with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=True):
+        with patch("health_azure.paths.shared_himl_conda_env_file", return_value=temp_env_path):
+            # Calling check_conda_environments on an empty list should do nothing
+            check_conda_environments([])
+
+            # Pass a non-empty list and mock the rturn value of is_conda_file_with_pip_include
+            with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(True, None)):
+                with pytest.raises(ValueError) as e:
+                    check_conda_environments(['some_path'])
+                    assert "uses '-r' to reference pip requirements" in str(e)
+
+        # If the file that we pass is the same as the return value of shared_himl_conda_env_file
+        # an error will not be raised
+        with patch("health_azure.paths.shared_himl_conda_env_file", return_value='some_path'):
+            with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(True, None)):
+                check_conda_environments(['some_path'])
+
+        # If not is_conda_is_conda_file_with_pip_include, excpect nothing to happen
+        with patch("health_azure.paths.shared_himl_conda_env_file", return_value=temp_env_path):
+            with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(False, None)):
+                check_conda_environments(['some_path'])
+
+    # Now check cases where is_himl_used_from_git_repo is False:
+    with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=False):
+        # If not is_conda_is_conda_file_with_pip_include, excpect nothing to happen
+        with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(False, None)):
+            check_conda_environments([])
+            check_conda_environments(['some_path'])
+
+        # If is_conda_is_conda_file_with_pip_include=True, expect a ValueError to be raised
+        with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(True, None)):
+            with pytest.raises(ValueError) as e:
+                check_conda_environments(['some_path'])
+                assert "uses '-r' to reference pip requirements" in str(e)

--- a/hi-ml/testhiml/testhiml/utils/test_common_utils.py
+++ b/hi-ml/testhiml/testhiml/utils/test_common_utils.py
@@ -102,29 +102,29 @@ def test_check_conda_environments(temp_env_path: Path) -> None:
             # Pass a non-empty list and mock the rturn value of is_conda_file_with_pip_include
             with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(True, None)):
                 with pytest.raises(ValueError) as e:
-                    check_conda_environments(['some_path'])
+                    check_conda_environments([Path('some_path')])
                     assert "uses '-r' to reference pip requirements" in str(e)
 
         # If the file that we pass is the same as the return value of shared_himl_conda_env_file
         # an error will not be raised
-        with patch("health_azure.paths.shared_himl_conda_env_file", return_value='some_path'):
+        with patch("health_azure.paths.shared_himl_conda_env_file", return_value=Path('some_path')):
             with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(True, None)):
-                check_conda_environments(['some_path'])
+                check_conda_environments([Path('some_path')])
 
         # If not is_conda_is_conda_file_with_pip_include, excpect nothing to happen
         with patch("health_azure.paths.shared_himl_conda_env_file", return_value=temp_env_path):
             with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(False, None)):
-                check_conda_environments(['some_path'])
+                check_conda_environments([Path('some_path')])
 
     # Now check cases where is_himl_used_from_git_repo is False:
     with patch("health_azure.paths.is_himl_used_from_git_repo", return_value=False):
         # If not is_conda_is_conda_file_with_pip_include, excpect nothing to happen
         with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(False, None)):
             check_conda_environments([])
-            check_conda_environments(['some_path'])
+            check_conda_environments([Path('some_path')])
 
         # If is_conda_is_conda_file_with_pip_include=True, expect a ValueError to be raised
         with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(True, None)):
             with pytest.raises(ValueError) as e:
-                check_conda_environments(['some_path'])
+                check_conda_environments([Path('some_path')])
                 assert "uses '-r' to reference pip requirements" in str(e)

--- a/hi-ml/testhiml/testhiml/utils/test_common_utils.py
+++ b/hi-ml/testhiml/testhiml/utils/test_common_utils.py
@@ -89,7 +89,7 @@ def test_get_all_environment_files(temp_project_root: Path, temp_env_path: Path,
         with patch("health_azure.paths.git_repo_root_folder", return_value=empty_temp_dir):
             with pytest.raises(ValueError) as e2:
                 get_all_environment_files(project_root=empty_temp_dir)
-                assert "No Conda environment files were found in the repository" in str(e2)
+            assert "No Conda environment files were found in the repository" in str(e2)
 
 
 @pytest.mark.fast
@@ -103,7 +103,7 @@ def test_check_conda_environments(temp_env_path: Path) -> None:
             with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(True, None)):
                 with pytest.raises(ValueError) as e:
                     check_conda_environments([Path('some_path')])
-                    assert "uses '-r' to reference pip requirements" in str(e)
+                assert "uses '-r' to reference pip requirements" in str(e)
 
         # If the file that we pass is the same as the return value of shared_himl_conda_env_file
         # an error will not be raised
@@ -127,4 +127,4 @@ def test_check_conda_environments(temp_env_path: Path) -> None:
         with patch("health_ml.utils.common_utils.is_conda_file_with_pip_include", return_value=(True, None)):
             with pytest.raises(ValueError) as e:
                 check_conda_environments([Path('some_path')])
-                assert "uses '-r' to reference pip requirements" in str(e)
+            assert "uses '-r' to reference pip requirements" in str(e)


### PR DESCRIPTION
When splitting repo into multiple workspaces, `hi-ml/environment.yml` was moved to  `hi-ml/hi-ml/environment.yml`.  The logic in get_all_environment_files is therefore out of date.

Also update check_conda_environments along the same lines, and add/ update tests for all of the above.