### PR TITLE
BUG: Update paths and columns for PANDA tiles dataset  

### DIFF
--- a/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
+++ b/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
@@ -12,6 +12,8 @@ from SSL.utils import SSLTrainingType
 from health_azure.utils import is_running_in_azure_ml
 from histopathology.datasets.panda_tiles_dataset import PandaTilesDatasetWithReturnIndex
 from histopathology.configs.SSL.HistoSimCLRContainer import HistoSSLContainer
+from histopathology.datasets.default_paths import PANDA_TILES_DATASET_ID
+
 
 current_file = Path(__file__)
 print(f"Running container from {current_file}")
@@ -39,7 +41,7 @@ class PANDA_SimCLR(HistoSSLContainer):
 
         super().__init__(ssl_training_dataset_name=SSLDatasetNameHiml.PANDA,
                          linear_head_dataset_name=SSLDatasetNameHiml.PANDA,
-                         azure_datasets=['PANDA_tiles_20220427'],
+                         azure_datasets=[PANDA_TILES_DATASET_ID],
                          random_seed=1,
                          num_workers=num_workers,
                          is_debug_model=is_debug_model,

--- a/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
+++ b/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
@@ -39,7 +39,7 @@ class PANDA_SimCLR(HistoSSLContainer):
 
         super().__init__(ssl_training_dataset_name=SSLDatasetNameHiml.PANDA,
                          linear_head_dataset_name=SSLDatasetNameHiml.PANDA,
-                         azure_datasets=['PANDA_tiles'],
+                         azure_datasets=['PANDA_tiles_20220427'],
                          random_seed=1,
                          num_workers=num_workers,
                          is_debug_model=is_debug_model,

--- a/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
@@ -19,7 +19,11 @@ from histopathology.models.encoders import (
     SSLEncoder)
 from histopathology.configs.classification.BaseMIL import BaseMILSlides, BaseMILTiles, BaseMIL
 from histopathology.datasets.panda_dataset import PandaDataset
-from histopathology.datasets.default_paths import PANDA_DATASET_DIR, PANDA_DATASET_ID, PANDA_TILES_DATASET_DIR, PANDA_TILES_DATASET_ID
+from histopathology.datasets.default_paths import (
+    PANDA_DATASET_DIR,
+    PANDA_DATASET_ID,
+    PANDA_TILES_DATASET_DIR,
+    PANDA_TILES_DATASET_ID)
 
 
 class BaseDeepSMILEPanda(BaseMIL):

--- a/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
@@ -19,6 +19,7 @@ from histopathology.models.encoders import (
     SSLEncoder)
 from histopathology.configs.classification.BaseMIL import BaseMILSlides, BaseMILTiles, BaseMIL
 from histopathology.datasets.panda_dataset import PandaDataset
+from histopathology.datasets.default_paths import PANDA_DATASET_DIR, PANDA_DATASET_ID, PANDA_TILES_DATASET_DIR, PANDA_TILES_DATASET_ID
 
 
 class BaseDeepSMILEPanda(BaseMIL):
@@ -61,8 +62,8 @@ class DeepSMILETilesPanda(BaseMILTiles, BaseDeepSMILEPanda):
             # declared in BaseMILTiles:
             is_caching=False,
             # declared in DatasetParams:
-            local_datasets=[Path("/tmp/datasets/PANDA_tiles_20220427"), Path("/tmp/datasets/PANDA")],
-            azure_datasets=["PANDA_tiles_20220427", "PANDA"])
+            local_datasets=[Path(PANDA_TILES_DATASET_DIR), Path(PANDA_DATASET_DIR)],
+            azure_datasets=[PANDA_TILES_DATASET_ID, PANDA_DATASET_ID])
         default_kwargs.update(kwargs)
         super().__init__(**default_kwargs)
 

--- a/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILEPanda.py
@@ -61,8 +61,8 @@ class DeepSMILETilesPanda(BaseMILTiles, BaseDeepSMILEPanda):
             # declared in BaseMILTiles:
             is_caching=False,
             # declared in DatasetParams:
-            local_datasets=[Path("/tmp/datasets/PANDA_tiles"), Path("/tmp/datasets/PANDA")],
-            azure_datasets=["PANDA_tiles", "PANDA"])
+            local_datasets=[Path("/tmp/datasets/PANDA_tiles_20220427"), Path("/tmp/datasets/PANDA")],
+            azure_datasets=["PANDA_tiles_20220427", "PANDA"])
         default_kwargs.update(kwargs)
         super().__init__(**default_kwargs)
 

--- a/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
@@ -95,9 +95,12 @@ class TilesDataset(Dataset):
         """
         columns = [self.SLIDE_ID_COLUMN, self.IMAGE_COLUMN, self.LABEL_COLUMN,
                    self.SPLIT_COLUMN, self.TILE_X_COLUMN, self.TILE_Y_COLUMN]
+        columns_not_found = []
         for column in columns:
             if column is not None and column not in self.dataset_df.columns:
-                raise ValueError(f"Expected column '{column}' not found in the dataframe")
+                columns_not_found.append(column)
+        if len(columns_not_found) > 0:
+            raise ValueError(f"Expected columns '{columns_not_found}' not found in the dataframe")
 
     def __len__(self) -> int:
         return self.dataset_df.shape[0]
@@ -204,9 +207,12 @@ class SlidesDataset(Dataset):
         """
         columns = [self.IMAGE_COLUMN, self.LABEL_COLUMN, self.MASK_COLUMN,
                    self.SPLIT_COLUMN] + list(self.METADATA_COLUMNS)
+        columns_not_found = []
         for column in columns:
             if column is not None and column not in self.dataset_df.columns:
-                raise ValueError(f"Expected column '{column}' not found in the dataframe")
+                columns_not_found.append(column)
+        if len(columns_not_found) > 0:
+            raise ValueError(f"Expected columns '{columns_not_found}' not found in the dataframe")
 
     def __len__(self) -> int:
         return self.dataset_df.shape[0]

--- a/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
@@ -62,7 +62,7 @@ class TilesDataset(Dataset):
         from the dataset CSV file, e.g. after some filtering. If given, overrides `dataset_csv`.
         :param train: If `True`, loads only the training split (resp. `False` for test split). By
         default (`None`), loads the entire dataset as-is.
-        :param validate_columns: Whether to call `validate_columns()` at the end of `__init__()`. 
+        :param validate_columns: Whether to call `validate_columns()` at the end of `__init__()`.
         `validate_columns()` checks that the loaded data frame for the dataset contains the expected column names
         for this class
         """

--- a/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
@@ -96,7 +96,7 @@ class TilesDataset(Dataset):
         for column in columns:
             if column is not None and column not in self.dataset_df.columns:
                 raise ValueError(f"Expected column '{column}' not found in the dataframe")
-    
+
     def __len__(self) -> int:
         return self.dataset_df.shape[0]
 

--- a/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
@@ -81,7 +81,7 @@ class TilesDataset(Dataset):
         else:
             split = self.TRAIN_SPLIT_LABEL if train else self.TEST_SPLIT_LABEL
             self.dataset_df = dataset_df[dataset_df[self.SPLIT_COLUMN] == split]
-        
+ 
         if validate_columns:
             self.validate_columns()
 

--- a/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
@@ -81,7 +81,7 @@ class TilesDataset(Dataset):
         else:
             split = self.TRAIN_SPLIT_LABEL if train else self.TEST_SPLIT_LABEL
             self.dataset_df = dataset_df[dataset_df[self.SPLIT_COLUMN] == split]
- 
+
         if validate_columns:
             self.validate_columns()
 

--- a/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
@@ -62,7 +62,9 @@ class TilesDataset(Dataset):
         from the dataset CSV file, e.g. after some filtering. If given, overrides `dataset_csv`.
         :param train: If `True`, loads only the training split (resp. `False` for test split). By
         default (`None`), loads the entire dataset as-is.
-        :param validate_columns: Whether to call `validate_columns()` at the end of `__init__()`.
+        :param validate_columns: Whether to call `validate_columns()` at the end of `__init__()`. 
+        `validate_columns()` checks that the loaded data frame for the dataset contains the expected column names
+        for this class
         """
         if self.SPLIT_COLUMN is None and train is not None:
             raise ValueError("Train/test split was specified but dataset has no split column")
@@ -170,6 +172,8 @@ class SlidesDataset(Dataset):
         :param train: If `True`, loads only the training split (resp. `False` for test split). By
         default (`None`), loads the entire dataset as-is.
         :param validate_columns: Whether to call `validate_columns()` at the end of `__init__()`.
+        `validate_columns()` checks that the loaded data frame for the dataset contains the expected column names
+        for this class
         """
         if self.SPLIT_COLUMN is None and train is not None:
             raise ValueError("Train/test split was specified but dataset has no split column")

--- a/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/base_dataset.py
@@ -75,15 +75,15 @@ class TilesDataset(Dataset):
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
             dataset_df = pd.read_csv(self.dataset_csv)
 
-        if validate_columns:
-            self.validate_columns()
-
         dataset_df = dataset_df.set_index(self.TILE_ID_COLUMN)
         if train is None:
             self.dataset_df = dataset_df
         else:
             split = self.TRAIN_SPLIT_LABEL if train else self.TEST_SPLIT_LABEL
             self.dataset_df = dataset_df[dataset_df[self.SPLIT_COLUMN] == split]
+        
+        if validate_columns:
+            self.validate_columns()
 
     def validate_columns(self) -> None:
         """Check that loaded dataframe contains expected columns, raises `ValueError` otherwise.

--- a/hi-ml-histopathology/src/histopathology/datasets/default_paths.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/default_paths.py
@@ -4,7 +4,7 @@
 #  ------------------------------------------------------------------------------------------
 
 PANDA_DATASET_ID = "PANDA"
-PANDA_TILES_DATASET_ID = "PANDA_tiles"
+PANDA_TILES_DATASET_ID = "PANDA_tiles_20220427"
 TCGA_CRCK_DATASET_ID = "TCGA-CRCk"
 TCGA_PRAD_DATASET_ID = "TCGA-PRAD"
 

--- a/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
@@ -52,7 +52,8 @@ class PandaTilesDataset(TilesDataset):
 
         # Change "left" --> "tile_x" and "top" --> "tile_y"
         # to be consistent with TilesDataset `TILE_X_COLUMN` and `TILE_Y_COLUMN`
-        self.dataset_df.rename(columns={"left": "tile_x", "top": "tile_y"}, inplace=True)
+        self.dataset_df.rename(columns={"left": TilesDataset.TILE_X_COLUMN, "top": TilesDataset.TILE_Y_COLUMN},
+                               inplace=True)
         self.validate_columns()
 
 

--- a/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
@@ -31,7 +31,7 @@ class PandaTilesDataset(TilesDataset):
     SPLIT_COLUMN = None  # PANDA does not have an official train/test split
     N_CLASSES = 6
 
-    _RELATIVE_ROOT_FOLDER = Path("PANDA_tiles_20220427/panda_tiles_level1_224")
+    _RELATIVE_ROOT_FOLDER = Path("panda_tiles_level1_224")
 
     def __init__(self,
                  root: Path,
@@ -41,13 +41,19 @@ class PandaTilesDataset(TilesDataset):
         super().__init__(root=Path(root) / self._RELATIVE_ROOT_FOLDER,
                          dataset_csv=dataset_csv,
                          dataset_df=dataset_df,
-                         train=None)
+                         train=None,
+                         validate_columns=False)
         if occupancy_threshold is not None:
             self.dataset_df: pd.DataFrame
             dataset_df_filtered = self.dataset_df.loc[
                 self.dataset_df['occupancy'] > occupancy_threshold
             ]
             self.dataset_df = dataset_df_filtered
+
+        # Change "left" --> "tile_x" and "top" --> "tile_y"
+        # to be consistent with TilesDataset `TILE_X_COLUMN` and `TILE_Y_COLUMN`
+        self.dataset_df.rename(columns={"left": "tile_x", "top": "tile_y"}, inplace=True)
+        self.validate_columns()
 
 
 class PandaTilesDatasetReturnImageLabel(VisionDataset):


### PR DESCRIPTION
In this PR:
- Paths are updated to point to the new PANDA tiles dataset created by @fepegar in https://github.com/microsoft/hi-ml/pull/325
- Columns `left` and `top` in the new tiles CSV are mapped to `tile_x` and `tile_y` of TilesDataset as the latter are being used to save batch outputs.
