### PR TITLE
BUG: Fix problem with Test.PyPi upload filename conflicts

### DIFF
--- a/hi-ml-azure/setup.py
+++ b/hi-ml-azure/setup.py
@@ -48,10 +48,10 @@ if not version:
         # In github workflows, tests for hi-ml pull in hi-ml-azure as a dependency. Usually, we have a condition like
         # hi-ml-azure>=0.1.5. This means that a package version from PyPi would trump the local wheels. For this reason,
         # use an extremely large version number to give the local wheel priority.
-        version = '99.99.post' + build_number
+        version = '99.991.post' + build_number
     else:
         default_random_version_number = floor(random() * 10_000_000_000)
-        version = f'99.99.post{str(default_random_version_number)}'
+        version = f'99.991.post{str(default_random_version_number)}'
 
 (here / 'package_name.txt').write_text('hi-ml-azure')
 (here / 'latest_version.txt').write_text(version)

--- a/hi-ml/setup.py
+++ b/hi-ml/setup.py
@@ -47,7 +47,7 @@ if not version:
     # runs, one which circumvents AzureML's apparent package caching:
     build_number = os.getenv('GITHUB_RUN_NUMBER')
     if build_number:
-        version = '0.1.0.post' + build_number
+        version = '0.1.1.post' + build_number
     else:
         default_random_version_number = floor(random() * 10_000_000_000)
         version = f'0.1.0.post{str(default_random_version_number)}'


### PR DESCRIPTION
Because we renamed a workflow, run number counting started back at 1. This now creates version clashes with the existing test.pypi packages from the very early days where run numbers also started at 1. Resolve by using a different prefix