### PR TITLE
ENH: Add pl_limit_batches to TrainerConfigs.

### DIFF
--- a/hi-ml/src/health_ml/deep_learning_config.py
+++ b/hi-ml/src/health_ml/deep_learning_config.py
@@ -397,6 +397,10 @@ class TrainerParams(param.Parameterized):
         param.Number(default=None,
                      doc="PyTorch Lightning trainer flag 'limit_test_batches': Limit the test dataset to the "
                          "given number of batches if integer, or proportion of test dataset if float.")
+    pl_limit_batches: Optional[IntOrFloat] = \
+        param.Number(default=None,
+                     doc="PyTorch Lightning trainer flag 'fast_dev_run': Limit the test dataset to the "
+                         "given number of batches if integer, or proportion of test dataset if float.")
     pl_profiler: Optional[str] = \
         param.String(default=None,
                      doc="The value to use for the 'profiler' argument for the Lightning trainer. "

--- a/hi-ml/src/health_ml/deep_learning_config.py
+++ b/hi-ml/src/health_ml/deep_learning_config.py
@@ -21,7 +21,7 @@ from health_ml.utils.common_utils import (CHECKPOINT_FOLDER,
                                           create_unique_timestamp_id,
                                           DEFAULT_AML_UPLOAD_DIR,
                                           DEFAULT_LOGS_DIR_NAME)
-from health_ml.utils.type_annotations import IntOrFloat, TupleFloat2
+from health_ml.utils.type_annotations import IntOrFloat, TupleFloat2, IntOrBool
 
 
 @unique
@@ -397,10 +397,10 @@ class TrainerParams(param.Parameterized):
         param.Number(default=None,
                      doc="PyTorch Lightning trainer flag 'limit_test_batches': Limit the test dataset to the "
                          "given number of batches if integer, or proportion of test dataset if float.")
-    pl_limit_batches: Optional[IntOrFloat] = \
-        param.Number(default=None,
-                     doc="PyTorch Lightning trainer flag 'fast_dev_run': Limit the test dataset to the "
-                         "given number of batches if integer, or proportion of test dataset if float.")
+    pl_limit_batches: Optional[IntOrBool] = \
+        param.Number(default=False,
+                     doc="PyTorch Lightning trainer flag 'fast_dev_run': Runs n if set to ``n`` (int) else 1 if set to"
+                         "``True`` batch(es) of train, val and test to" "find any bugs (ie: a sort of unit test).")
     pl_profiler: Optional[str] = \
         param.String(default=None,
                      doc="The value to use for the 'profiler' argument for the Lightning trainer. "

--- a/hi-ml/src/health_ml/model_trainer.py
+++ b/hi-ml/src/health_ml/model_trainer.py
@@ -163,6 +163,7 @@ def create_lightning_trainer(container: LightningContainer,
                       profiler=container.pl_profiler,
                       resume_from_checkpoint=str(resume_from_checkpoint) if resume_from_checkpoint else None,
                       multiple_trainloader_mode=multiple_trainloader_mode,
+                      fast_dev_run=2,
                       **additional_args)
     return trainer, storing_logger
 

--- a/hi-ml/src/health_ml/model_trainer.py
+++ b/hi-ml/src/health_ml/model_trainer.py
@@ -151,6 +151,7 @@ def create_lightning_trainer(container: LightningContainer,
                       limit_train_batches=container.pl_limit_train_batches or 1.0,
                       limit_val_batches=container.pl_limit_val_batches or 1.0,
                       limit_test_batches=container.pl_limit_test_batches or 1.0,
+                      fast_dev_run=container.pl_limit_batches,
                       num_sanity_val_steps=container.pl_num_sanity_val_steps,
                       # check_val_every_n_epoch=container.pl_check_val_every_n_epoch,
                       callbacks=callbacks,
@@ -163,7 +164,6 @@ def create_lightning_trainer(container: LightningContainer,
                       profiler=container.pl_profiler,
                       resume_from_checkpoint=str(resume_from_checkpoint) if resume_from_checkpoint else None,
                       multiple_trainloader_mode=multiple_trainloader_mode,
-                      fast_dev_run=2,
                       **additional_args)
     return trainer, storing_logger
 

--- a/hi-ml/src/health_ml/utils/type_annotations.py
+++ b/hi-ml/src/health_ml/utils/type_annotations.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple, TypeVar, Union
 
 T = TypeVar('T')
 IntOrFloat = Union[int, float]
+IntOrBool = Union[int, bool]
 PathOrString = Union[Path, str]
 TupleFloat2 = Tuple[float, float]
 TupleInt3 = Tuple[int, int, int]


### PR DESCRIPTION
Enable pytorch lightning flag "fast_dev_run" in our pipeline to be able to limit the number of train/test/val batches at once for fast debugging.