### PR TITLE
ENH: Add log text reader function

### DIFF
--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -44,7 +44,7 @@ python sample.py -n 103 --azureml
 then the function `submit_to_azure_if_needed` will perform all the required actions to run this script in AzureML and exit. Note that:
 
 * code after `submit_to_azure_if_needed` is not run locally, but it is run in AzureML.
-* the print statement prints to the AzureML console output and is available in the `Output + logs` tab of the experiment in the `70_driver_log.txt` file, and can be downloaded from there.
+* the print statement prints to the AzureML console output and is available in the `Output + logs` tab of the experiment in the `70_driver_log.txt` if using the old AzureML runtime, or `std_log.txt` if using the new AzureML runtime, and can be downloaded from there.
 * the command line arguments are passed through (apart from --azureml) when running in AzureML.
 * a new file: `most_recent_run.txt` will be created containing an identifier of this AzureML run.
 

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1466,7 +1466,7 @@ def get_driver_log_file_text(run: Run, download_file: bool = True) -> Optional[s
 
     :param run: Run object representing the current run.
     :param download_file: If ``True``, download log file from the run.
-    :return: Driver log file text if a file exists, `None` otherwise.
+    :return: Driver log file text if a file exists, ``None`` otherwise.
     """
     with tempfile.TemporaryDirectory() as tmp_dir_name:
 
@@ -1481,7 +1481,7 @@ def get_driver_log_file_text(run: Run, download_file: bool = True) -> Optional[s
             if tmp_log_file_path.is_file():
                 return tmp_log_file_path.read_text()
 
-    files_as_str = ', '.join([f"'{str(log_file_path)}'" for log_file_path in VALID_LOG_FILE_PATHS])
+    files_as_str = ', '.join(f"'{log_file_path}'" for log_file_path in VALID_LOG_FILE_PATHS)
     logging.warning(
         "Tried to get driver log file for run {run.id} text when no such file exists. Expected to find "
         f"one of the following: {files_as_str}"

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1462,8 +1462,7 @@ def download_files_from_run_id(
 
 def get_driver_log_file_text(run: Run, download_file: bool = True) -> Optional[str]:
     """
-    Return the text stored in the driver log file of that run. Detects log files produced
-    by both old and new runtimes.
+    Returns text stored in run log driver file.
 
     :param run: Run object representing the current run.
     :param download_file: Boolean flag that control if the log file should be downloaded from the run or not.

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1460,17 +1460,23 @@ def download_files_from_run_id(
 
 
 def get_driver_log_file_text(run: Run) -> Optional[str]:
-    """Given a run object, return the text stored in the driver log file of that run. Detects log files produced 
+    """Given a run object, return the text stored in the driver log file of that run. Detects log files produced
     by both old and new runtimes.
 
     :param run: Run object representing the current run.
     :return: Driver log file text if a file exists, None otherwise.
     """
     with tempfile.TemporaryDirectory() as tmp_dir_name:
-        run.download_files(prefix="azureml-logs", output_directory=tmp_dir_name,
-                            append_prefix=False)
-        run.download_files(prefix="user_logs", output_directory=tmp_dir_name,
-                            append_prefix=False)
+        run.download_files(
+            prefix="azureml-logs",
+            output_directory=tmp_dir_name,
+            append_prefix=False
+        )
+        run.download_files(
+            prefix="user_logs",
+            output_directory=tmp_dir_name,
+            append_prefix=False
+        )
 
         for log_file_name in ["70_driver_log.txt", "std_log.txt"]:
             driver_log_path = Path(tmp_dir_name) / log_file_name
@@ -1479,6 +1485,7 @@ def get_driver_log_file_text(run: Run) -> Optional[str]:
 
     logging.warning("Tried to get driver log file text when no such file exists.")
     return None
+
 
 def _download_file_from_run(
     run: Run, filename: str, output_file: Path, validate_checksum: bool = False

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1465,7 +1465,7 @@ def get_driver_log_file_text(run: Run, download_file: bool = True) -> Optional[s
     Returns text stored in run log driver file.
 
     :param run: Run object representing the current run.
-    :param download_file: Boolean flag that control if the log file should be downloaded from the run or not.
+    :param download_file: If ``True``, download log file from the run.
     :return: Driver log file text if a file exists, `None` otherwise.
     """
     with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1460,7 +1460,7 @@ def download_files_from_run_id(
     torch_barrier()
 
 
-def get_driver_log_file_text(run: Run, download_file=True) -> Optional[str]:
+def get_driver_log_file_text(run: Run, download_file: bool = True) -> Optional[str]:
     """
     Return the text stored in the driver log file of that run. Detects log files produced
     by both old and new runtimes.
@@ -1478,8 +1478,9 @@ def get_driver_log_file_text(run: Run, download_file=True) -> Optional[str]:
                     output_directory=tmp_dir_name,
                     append_prefix=False,
                 )
-            if log_file_path.is_file():
-                return log_file_path.read_text()
+            tmp_log_file_path = tmp_dir_name / log_file_path
+            if tmp_log_file_path.is_file():
+                return tmp_log_file_path.read_text()
 
     files_as_str = ', '.join([f"'{str(log_file_path)}'" for log_file_path in VALID_LOG_FILE_PATHS])
     logging.warning(

--- a/hi-ml-azure/testazure/testazure/test_himl.py
+++ b/hi-ml-azure/testazure/testazure/test_himl.py
@@ -885,13 +885,14 @@ def render_and_run_test_script(path: Path,
         # TODO: upgrade to walrus operator when upgrading python version to 3.8+
         # if log_text := get_driver_log_file_text(run=run):
         log_text = get_driver_log_file_text(run=run)
-        if log_text is not None:
-            return log_text
 
-        raise ValueError(
-            "The run does not contain any of the following log files: "
-            f"{[str(log_file_path) for log_file_path in VALID_LOG_FILE_PATHS]}"
-        )
+        if log_text is None:
+            raise ValueError(
+                "The run does not contain any of the following log files: "
+                f"{[log_file_path for log_file_path in VALID_LOG_FILE_PATHS]}"
+            )
+
+        return log_text
 
 
 @pytest.mark.parametrize("run_target", [RunTarget.LOCAL, RunTarget.AZUREML])


### PR DESCRIPTION
Adds a util function for reading the text contained in log files. Designed to work for boht `std_log.txt` (new runtime) and `70_driver_log.txt`. Used only once so far in hi-ml but has use in other tasks in InnerEye, such as [here](https://github.com/microsoft/InnerEye-Inference/issues/35).