### PR TITLE
ENH: Group code coverage by folder

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
+comment:
+  # Skip the "diff" part of the report because it shows lots of misleading red lines when not everything is uploaded
+  layout: "reach, flags, files"
 flags:
   hi-ml:
     paths:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+flags:
+  hi-ml:
+    paths:
+      - hi-ml
+    carryforward: true
+  hi-ml-azure:
+    paths:
+      - hi-ml-azure
+    carryforward: true
+  hi-ml-histopathology:
+    paths:
+      - hi-ml-histopathology
+    carryforward: true

--- a/.github/workflows/hi-ml-pr.yml
+++ b/.github/workflows/hi-ml-pr.yml
@@ -205,7 +205,7 @@ jobs:
         if: ${{ matrix.packageName == '*.whl' }}
         uses: codecov/codecov-action@v2
         with:
-            name: ${{ matrix.folder }}
+            flags: ${{ matrix.folder }}
 
   publish-testpypi-pkg:
     runs-on: ubuntu-18.04

--- a/.github/workflows/histopathology-pr.yml
+++ b/.github/workflows/histopathology-pr.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v2
         with:
-            name: ${{ env.folder }}
+            flags: ${{ env.folder }}
 
       - name: Run GPU tests
         run: |


### PR DESCRIPTION
Using the [Codecov flags](https://docs.codecov.com/docs/flags) to get better reporting for monorepos