### PR TITLE
ENH: Add pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   - id: check-shebang-scripts-are-executable  # Checks that scripts with shebangs are executable
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 3.9.2
+  rev: 4.0.1
   hooks:
   - id: flake8
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+# See https://github.com/pre-commit/pre-commit-hooks/blob/master/.pre-commit-config.yaml for an example with more hooks
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.2.0
+  hooks:
+  - id: check-ast                  # Simply check whether the files parse as valid python
+  - id: check-yaml                 # Attempts to load all yaml files to verify syntax
+
+  - id: check-added-large-files    # Prevent giant files from being committed
+  - id: check-docstring-first      # Checks a common error of defining a docstring after code
+  - id: check-merge-conflict       # Check for files that contain merge conflict strings
+  - id: check-vcs-permalinks       # Ensures that links to vcs websites are permalinks
+  - id: detect-private-key         # Detects the presence of private keys
+  - id: end-of-file-fixer          # Ensures that a file is either empty, or ends with one newline
+  - id: trailing-whitespace        # This hook trims trailing whitespace
+  - id: mixed-line-ending          # Replaces or checks mixed line ending
+  - id: check-shebang-scripts-are-executable  # Checks that scripts with shebangs are executable
+
+- repo: https://github.com/PyCQA/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+
+- repo: https://github.com/pre-commit/mirrors-autopep8
+  rev: v1.5.7
+  hooks:
+  - id: autopep8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,26 @@ repos:
   - id: mixed-line-ending          # Replaces or checks mixed line ending
   - id: check-shebang-scripts-are-executable  # Checks that scripts with shebangs are executable
 
+# The structure of this was suggested by the author of pre-commit and maintainer of flake8
+# See https://stackoverflow.com/a/66485642/3956024
 - repo: https://github.com/PyCQA/flake8
   rev: 4.0.1
   hooks:
   - id: flake8
+    name: flake8 ./hi-ml/
+    alias: flake8-hi-ml
+    files: ^hi-ml/
+    args: [--config, hi-ml/.flake8]
+  - id: flake8
+    name: flake8 ./hi-ml-azure/
+    alias: flake8-hi-ml-azure
+    files: ^hi-ml-azure/
+    args: [--config, hi-ml-azure/.flake8]
+  - id: flake8
+    name: flake8 ./hi-ml-histopathology/
+    alias: flake8-hi-ml-histopathology
+    files: ^hi-ml-histopathology/
+    args: [--config, hi-ml-histopathology/.flake8]
 
 - repo: https://github.com/pre-commit/mirrors-autopep8
   rev: v1.5.7

--- a/hi-ml-histopathology/environment.yml
+++ b/hi-ml-histopathology/environment.yml
@@ -17,6 +17,7 @@ dependencies:
       - matplotlib==3.4.3
       - opencv-python-headless==4.5.1.48
       - pandas==1.3.4
+      - pre-commit==2.19.0
       - pytorch-lightning==1.5.5
       - rpdb==0.1.6
       - setuptools==59.5.0

--- a/hi-ml-histopathology/requirements_test.txt
+++ b/hi-ml-histopathology/requirements_test.txt
@@ -2,6 +2,7 @@ black==22.1.0
 coverage==6.3.2
 flake8==4.0.1
 mypy==0.931
+pre-commit==2.19.0
 pylint==2.12.2
 pycobertura==2.0.1
 pytest==6.2.2

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,7 @@ black==22.1.0
 coverage==6.3.2
 flake8==4.0.1
 mypy==0.931
+pre-commit==2.19.0
 pylint==2.12.2
 pycobertura==2.0.1
 pytest==6.2.2


### PR DESCRIPTION
Related to:
- #298
- #342
- #345
- #346
- #347
- #348
- #349

TODO:
- [x] Add `pre-commit` to requirements
- [ ] Add installation instructions in documentation, maybe in #298?
- [ ] Add `pre-commit` bot: https://pre-commit.ci. I will ask Microsoft to approve the app first