### PR TITLE
BUG: Remove padding when loading slides

### DIFF
--- a/hi-ml-histopathology/src/histopathology/datasets/default_paths.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/default_paths.py
@@ -4,7 +4,7 @@
 #  ------------------------------------------------------------------------------------------
 
 PANDA_DATASET_ID = "PANDA"
-PANDA_TILES_DATASET_ID = "PANDA_tiles_20220427"
+PANDA_TILES_DATASET_ID = "PANDA_tiles_20220530"
 TCGA_CRCK_DATASET_ID = "TCGA-CRCk"
 TCGA_PRAD_DATASET_ID = "TCGA-PRAD"
 

--- a/hi-ml-histopathology/src/histopathology/preprocessing/create_panda_tiles_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/preprocessing/create_panda_tiles_dataset.py
@@ -288,7 +288,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--margin",
         type=int,
-        default=64,
+        default=0,
     )
     parser.add_argument(
         "--min-occupancy",


### PR DESCRIPTION
Fixes #314.

Cucim adds black padding when loading slides using a bounding box that is not fully within the slide's field of view.
Some margin can be added to bounding boxes in `LoadPandaROId`, but that's not needed in this application.
This PR sets padding (`margin`) to 0 when creating the tiles dataset, therefore 

I will also upload the new data set to Azure and modify the dataset name in our code.

<!--
## Guidelines

Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:

- Ensure that your PR is small, and implements one change
- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/CONTRIBUTING.md))
- Link the correct GitHub issue for tracking
- Add unit tests for all functions that you introduced or modified
- Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder

## Change the default merge message

When completing your PR, you will be asked for a title and an optional extended description. By default, the extended description will be a concatenation of the individual
commit messages. Please DELETE/REPLACE that with a human readable extended description for non-trivial PRs.
-->
