### PR TITLE
ENH: Add visualization parameters to DSA annotations script

### DIFF
--- a/hi-ml-histopathology/src/histopathology/utils/girder.py
+++ b/hi-ml-histopathology/src/histopathology/utils/girder.py
@@ -290,6 +290,7 @@ class Item:
     :raises ValueError: If no ID or JSON is passed.
     :raises ValueError: If both an ID and JSON are passed.
     """
+
     def __init__(self, dsa: DigitalSlideArchive, id: Optional[str] = None, json: Optional[Dict] = None):
         self._dsa = dsa
 
@@ -327,6 +328,7 @@ class RunOutputs:
     :param workspace_config_path: Path to an AML workspace configuration file, e.g., ``config.json``.
     :param overwrite_csv: Force download of the output CSV even when it is found locally.
     """
+
     def __init__(
         self,
         run_id: str,
@@ -535,6 +537,18 @@ if __name__ == "__main__":
         help="Just log into the DSA and exit. Useful to ensure connection to the DSA from current host",
     )
     parser.add_argument(
+        "--rescale",
+        action="store_true",
+        help="Rescale attention values between 0 and 1 to maximize heatmaps contrast",
+    )
+    parser.add_argument(
+        "--colormap",
+        type=str,
+        choices=plt.colormaps(),
+        default="Greens",
+        help="Matplotlib colormap used for the heatmaps",
+    )
+    parser.add_argument(
         "--search-mode",
         type=str,
         choices=("full", "prefix"),
@@ -563,4 +577,6 @@ if __name__ == "__main__":
         max_slides=args.max_slides,
         id_filter=args.id_filter,
         search_mode=args.search_mode,
+        colormap_name=args.colormap,
+        rescale=args.rescale,
     )


### PR DESCRIPTION
This PR adds the `rescale` and `colormap` parameters to the script in the `girder` module, to improve flexibility and facilitate experimentation.

## Defaults

`Greens` is the default colormap because

1. It goes from white to a dark colour. This is nice because the slides background is typically white as well.
2. Green has the best contrast to the typical tissue colour (~magenta)

Rescaling is not performed by default because it might artificially emphasise attention values that are only slight larger than others. E.g., compare (0.04, 0.06, 0.95) and (0.32, 0.33, 0.34) with their rescaled equivalents: (0, 0.02, 1) and (0, 0.5, 1). The differences between values of the second array are very exaggerated. However, as pointed out in our meetings, this might not be relevant because the values depend on the number of tiles anyway, so we might as well simply use the logits. To be considered in the future.

## Screenshots

Default (no rescaling, `Greens`):

![Screenshot 2022-05-31 101513](https://user-images.githubusercontent.com/12688084/171140040-9be47074-ba67-4a9b-9142-c3064ea725cd.png)


Rescaling, `Greens:

![Screenshot 2022-05-31 101534](https://user-images.githubusercontent.com/12688084/171140099-cb28fc2b-742a-4b79-81a0-c97b0e2c8031.png)

No rescaling, `viridis`:

![Screenshot 2022-05-31 101555](https://user-images.githubusercontent.com/12688084/171141676-f201bcde-a7e9-4945-8fe1-e043b7f75bab.png)

Rescaling, `viridis`:

![Screenshot 2022-05-31 101612](https://user-images.githubusercontent.com/12688084/171141688-bc23eb9b-fd57-48f8-8da8-3f51a2947786.png)
