### PR TITLE
ENH: PANDA SSL with tile selection enabled (random or tile occupancy)

### DIFF
--- a/hi-ml-histopathology/src/histopathology/configs/SSL/HistoSimCLRContainer.py
+++ b/hi-ml-histopathology/src/histopathology/configs/SSL/HistoSimCLRContainer.py
@@ -57,8 +57,8 @@ class HistoSSLContainer(SSLContainer):
             transforms = [RandomResizedCrop(size=224),
                           RandomHorizontalFlip(p=0.5),
                           RandomApply([ColorJitter(brightness=0.8, contrast=0.8, saturation=0.8, hue=0.2)], 0.8),
-                          RandomGrayscale(p=0.2)]
-                          # GaussianBlur(int(224 * 0.1) + 1)]
+                          RandomGrayscale(p=0.2),
+                          GaussianBlur(int(224 * 0.1) + 1)]
         else:
             # TODO Are there some transformations that we want to apply anyway?
             # not sure it will work without, DualViewTransformWrapper will call

--- a/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
+++ b/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
@@ -55,7 +55,7 @@ class PANDA_SimCLR(HistoSSLContainer):
                          **kwargs)
         self.pl_check_val_every_n_epoch = 10
         PandaTilesDatasetWithReturnIndex.occupancy_threshold = 0
-        PandaTilesDatasetWithReturnIndex.random_selection = 1
+        PandaTilesDatasetWithReturnIndex.random_subset_fraction = 1
         if not is_running_in_azure_ml():
             self.is_debug_model = True
             self.num_workers = 0

--- a/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
+++ b/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
@@ -55,7 +55,7 @@ class PANDA_SimCLR(HistoSSLContainer):
                          **kwargs)
         self.pl_check_val_every_n_epoch = 10
         PandaTilesDatasetWithReturnIndex.occupancy_threshold = 0
-        PandaTilesDatasetWithReturnIndex.random_selection = 0
+        PandaTilesDatasetWithReturnIndex.random_selection = 1
         if not is_running_in_azure_ml():
             self.is_debug_model = True
             self.num_workers = 0

--- a/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
+++ b/hi-ml-histopathology/src/histopathology/configs/SSL/PANDA_SimCLRContainer.py
@@ -55,7 +55,7 @@ class PANDA_SimCLR(HistoSSLContainer):
                          **kwargs)
         self.pl_check_val_every_n_epoch = 10
         PandaTilesDatasetWithReturnIndex.occupancy_threshold = 0
-        PandaTilesDatasetWithReturnIndex.random_selection = 0.5
+        PandaTilesDatasetWithReturnIndex.random_selection = 0
         if not is_running_in_azure_ml():
             self.is_debug_model = True
             self.num_workers = 0

--- a/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
@@ -48,8 +48,9 @@ class PandaTilesDataset(TilesDataset):
         :param dataset_df: A potentially pre-processed dataframe in the same format as would be read
         from the dataset CSV file, e.g. after some filtering. If given, overrides `dataset_csv`.
         :occupancy_threshold: A value between 0-1 such that only tiles with occupancy > occupancy_threshold
-        will be selected.
-        :random_selection: A value between 0-1 such that this proportion of tiles will be randomly selected.
+        will be selected. If this is 0, all tiles are selected.
+        :random_selection: A value > 0 and <=1 such that this proportion of tiles will be randomly selected.
+        If this is 1, all tiles are selected.
         """
         super().__init__(root=Path(root) / self._RELATIVE_ROOT_FOLDER,
                          dataset_csv=dataset_csv,
@@ -60,16 +61,14 @@ class PandaTilesDataset(TilesDataset):
         if occupancy_threshold is not None:
             if (occupancy_threshold < 0) or (occupancy_threshold > 1):
                 raise ValueError(f"Occupancy threshold value {occupancy_threshold} should be in range 0-1.")
-            self.dataset_df: pd.DataFrame
             dataset_df_filtered = self.dataset_df.loc[
                 self.dataset_df['occupancy'] > occupancy_threshold
             ]
             self.dataset_df = dataset_df_filtered
 
         if random_selection is not None:
-            if (random_selection < 0) or (random_selection > 1):
-                raise ValueError(f"Random selection value {random_selection} should be in range 0-1.")
-            self.dataset_df: pd.DataFrame
+            if (random_selection <= 0) or (random_selection > 1):
+                raise ValueError(f"Random selection value {random_selection} should be > 0 and < = 1.")
             df_length_random_selection = round(len(self.dataset_df) * random_selection)
             dataset_df_filtered = self.dataset_df.sample(n=df_length_random_selection)
             self.dataset_df = dataset_df_filtered

--- a/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
@@ -88,7 +88,7 @@ class PandaTilesDatasetReturnImageLabel(VisionDataset):
     class label.
     """
     occupancy_threshold = 0
-    random_selection = 0
+    random_selection = 1
 
     def __init__(self,
                  root: Path,

--- a/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/datasets/panda_tiles_dataset.py
@@ -39,7 +39,7 @@ class PandaTilesDataset(TilesDataset):
                  dataset_csv: Optional[Union[str, Path]] = None,
                  dataset_df: Optional[pd.DataFrame] = None,
                  occupancy_threshold: Optional[float] = None,
-                 random_selection: Optional[float] = None) -> None:
+                 random_subset_fraction: Optional[float] = None) -> None:
         """
         :param root: Root directory of the dataset.
         :param dataset_csv: Full path to a dataset CSV file, containing at least
@@ -48,9 +48,9 @@ class PandaTilesDataset(TilesDataset):
         :param dataset_df: A potentially pre-processed dataframe in the same format as would be read
         from the dataset CSV file, e.g. after some filtering. If given, overrides `dataset_csv`.
         :occupancy_threshold: A value between 0-1 such that only tiles with occupancy > occupancy_threshold
-        will be selected. If this is 0, all tiles are selected.
-        :random_selection: A value > 0 and <=1 such that this proportion of tiles will be randomly selected.
-        If this is 1, all tiles are selected.
+        will be selected. If 0, all tiles are selected. If `None` (default), all tiles are selected.
+        :random_subset_fraction: A value > 0 and <=1 such that this proportion of tiles will be randomly selected.
+        If 1, all tiles are selected. If `None` (default), all tiles are selected.
         """
         super().__init__(root=Path(root) / self._RELATIVE_ROOT_FOLDER,
                          dataset_csv=dataset_csv,
@@ -66,11 +66,11 @@ class PandaTilesDataset(TilesDataset):
             ]
             self.dataset_df = dataset_df_filtered
 
-        if random_selection is not None:
-            if (random_selection <= 0) or (random_selection > 1):
-                raise ValueError(f"Random selection value {random_selection} should be > 0 and < = 1.")
-            df_length_random_selection = round(len(self.dataset_df) * random_selection)
-            dataset_df_filtered = self.dataset_df.sample(n=df_length_random_selection)
+        if random_subset_fraction is not None:
+            if (random_subset_fraction <= 0) or (random_subset_fraction > 1):
+                raise ValueError(f"Random subset fraction value {random_subset_fraction} should be > 0 and < = 1.")
+            df_length_random_subset_fraction = round(len(self.dataset_df) * random_subset_fraction)
+            dataset_df_filtered = self.dataset_df.sample(n=df_length_random_subset_fraction)
             self.dataset_df = dataset_df_filtered
 
         # Copy columns "left" --> "tile_x" and "top" --> "tile_y"
@@ -88,7 +88,7 @@ class PandaTilesDatasetReturnImageLabel(VisionDataset):
     class label.
     """
     occupancy_threshold = 0
-    random_selection = 1
+    random_subset_fraction = 1
 
     def __init__(self,
                  root: Path,
@@ -102,7 +102,7 @@ class PandaTilesDatasetReturnImageLabel(VisionDataset):
                                               dataset_csv=dataset_csv,
                                               dataset_df=dataset_df,
                                               occupancy_threshold=self.occupancy_threshold,
-                                              random_selection=self.random_selection)
+                                              random_subset_fraction=self.random_subset_fraction)
 
     def __getitem__(self, index: int) -> Tuple:  # type: ignore
         sample = self.base_dataset[index]


### PR DESCRIPTION
In this PR, 
- Configuration for PANDA SSL is updated to run locally and on Azure ML.
- Docs are updated to explain `occupancy_threshold` and `random_subset_fraction` parameters in `PandaTilesDataset`.
- Parameter `random_subset_fraction` is added to `PandaTilesDataset` to select a random subset of tiles.