### PR TITLE
ENH: Add gpu tests coverage to codecov reports

### DIFF
--- a/.github/workflows/histopathology-pr.yml
+++ b/.github/workflows/histopathology-pr.yml
@@ -16,7 +16,7 @@ on:
 env:
   pythonVersion: 3.7
   folder: hi-ml-histopathology
-  module: histopathology
+  module_for_coverage_reporting: histopathology
   HIML_TENANT_ID: ${{ secrets.HIML_TENANT_ID }}
   HIML_RESOURCE_GROUP: ${{ secrets.HIML_RESOURCE_GROUP }}
   HIML_SUBSCRIPTION_ID: ${{ secrets.HIML_SUBSCRIPTION_ID }}
@@ -116,7 +116,7 @@ jobs:
           branch_prefix="refs/heads/"
           full_branch_name=$GITHUB_REF
           branch_name_without_prefix=${full_branch_name#$branch_prefix}
-          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml --folder=${{ env.folder }} --module=${{ env.module }} --experiment="$branch_name_without_prefix"
+          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml --folder=${{ env.folder }} --coverage_module=${{ env.module_for_coverage_reporting }} --experiment="$branch_name_without_prefix"
 
       - name: Upload gpu tests coverage report to Codecov
         # Coverage should also be uploaded if tests still fail

--- a/.github/workflows/histopathology-pr.yml
+++ b/.github/workflows/histopathology-pr.yml
@@ -16,6 +16,7 @@ on:
 env:
   pythonVersion: 3.7
   folder: hi-ml-histopathology
+  module: histopathology
   HIML_TENANT_ID: ${{ secrets.HIML_TENANT_ID }}
   HIML_RESOURCE_GROUP: ${{ secrets.HIML_RESOURCE_GROUP }}
   HIML_SUBSCRIPTION_ID: ${{ secrets.HIML_SUBSCRIPTION_ID }}
@@ -115,7 +116,8 @@ jobs:
           branch_prefix="refs/heads/"
           full_branch_name=$GITHUB_REF
           branch_name_without_prefix=${full_branch_name#$branch_prefix}
-          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml --folder=${{ env.folder }} --experiment="$branch_name_without_prefix"
+          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml
+          --folder=${{ env.folder }} --module=${{ env.module }} --experiment="$branch_name_without_prefix"
 
       - name: Upload gpu tests coverage report to Codecov
         # Coverage should also be uploaded if tests still fail

--- a/.github/workflows/histopathology-pr.yml
+++ b/.github/workflows/histopathology-pr.yml
@@ -115,4 +115,12 @@ jobs:
           branch_prefix="refs/heads/"
           full_branch_name=$GITHUB_REF
           branch_name_without_prefix=${full_branch_name#$branch_prefix}
-          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml --folder=${{ env.folder }} --experiment="$branch_name_without_prefix"
+          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml
+          --folder=${{ env.folder }} --experiment="$branch_name_without_prefix"
+
+      - name: Upload gpu tests coverage report to Codecov
+        # Coverage should also be uploaded if tests still fail
+        if: always()
+        uses: codecov/codecov-action@v2
+        with:
+            flags: ${{ env.folder }}

--- a/.github/workflows/histopathology-pr.yml
+++ b/.github/workflows/histopathology-pr.yml
@@ -115,8 +115,7 @@ jobs:
           branch_prefix="refs/heads/"
           full_branch_name=$GITHUB_REF
           branch_name_without_prefix=${full_branch_name#$branch_prefix}
-          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml
-          --folder=${{ env.folder }} --experiment="$branch_name_without_prefix"
+          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml --folder=${{ env.folder }} --experiment="$branch_name_without_prefix"
 
       - name: Upload gpu tests coverage report to Codecov
         # Coverage should also be uploaded if tests still fail

--- a/.github/workflows/histopathology-pr.yml
+++ b/.github/workflows/histopathology-pr.yml
@@ -116,8 +116,7 @@ jobs:
           branch_prefix="refs/heads/"
           full_branch_name=$GITHUB_REF
           branch_name_without_prefix=${full_branch_name#$branch_prefix}
-          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml
-          --folder=${{ env.folder }} --module=${{ env.module }} --experiment="$branch_name_without_prefix"
+          python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml --folder=${{ env.folder }} --module=${{ env.module }} --experiment="$branch_name_without_prefix"
 
       - name: Upload gpu tests coverage report to Codecov
         # Coverage should also be uploaded if tests still fail

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -83,9 +83,9 @@ def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> No
     pytest_args = [folder_to_test, f"--junitxml={str(results_file)}"]
 
     if module_to_test:
-        pytest_args += [f"--cov={module_to_test}", "--cov-branch",
-                        f"--cov-report=html:{OUTPUT_FOLDER}/{PYTEST_GPU_COVERAGE_FILE}",
-                        "--cov-report=xml", "--cov-report=term-missing", "--cov-config=.coveragerc"]
+        pytest_args += [f"--cov={module_to_test}", "--cov-branch", "--cov-report=html",
+                        "--cov-report=xml::{OUTPUT_FOLDER}/{PYTEST_GPU_COVERAGE_FILE}",
+                        "--cov-report=term-missing", "--cov-config=.coveragerc"]
     if pytest_mark:
         pytest_args += ["-m", pytest_mark]
     logging.info(f"Starting pytest with these args: {pytest_args}")

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -103,7 +103,8 @@ def download_run_output_file(blob_path: Path, destination: Path, run: Run) -> Pa
     Downloads a single file from the run's default output directory: ("outputs").
 
     :param blob_path: The relative path to the file to download. For example, if blobs_path = "foo/bar.csv", then the
-        run result file "outputs/foo/bar.csv" will be downloaded to <destination>/bar.csv (the directory will be stripped off).
+        run result file "outputs/foo/bar.csv" will be downloaded to <destination>/bar.csv (the directory will be
+        stripped off).
     :param run: The AzureML run to download the files from.
     :param destination: Local path to save the downloaded blob to.
     :return: Destination path to the downloaded file(s).

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -101,9 +101,9 @@ def run_pytest(folder_to_test: str, pytest_mark: str, coverage_module: str) -> N
 def download_run_output_file(blob_path: Path, destination: Path, run: Run) -> Path:
     """
     Downloads a single file from the run's default output directory: ("outputs").
+
     :param blob_path: The relative path to the file to download. For example, if blobs_path = "foo/bar.csv", then the
-    run result file "outputs/foo/bar.csv" will be downloaded to <destination>/bar.csv
-    (the directory will be stripped off).
+        run result file "outputs/foo/bar.csv" will be downloaded to <destination>/bar.csv (the directory will be stripped off).
     :param run: The AzureML run to download the files from.
     :param destination: Local path to save the downloaded blob to.
     :return: Destination path to the downloaded file(s).

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -76,6 +76,7 @@ def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> No
 
     :param pytest_mark: The PyTest mark to use for filtering out the tests to run.
     :param folder_to_test: The folder with tests that should be run.
+    :param module_to_test: The module for which test code coverage should be run.
     """
     results_file = Path(OUTPUT_FOLDER) / PYTEST_RESULTS_FILE
     pytest_args = [folder_to_test, f"--junitxml={str(results_file)}"]

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -34,7 +34,7 @@ from health_azure.utils import (  # noqa: E402
     is_running_in_azure_ml,
     parse_arguments,
 )
-from health_ml.utils.common_utils import DEFAULT_AML_UPLOAD_DIR
+from health_ml.utils.common_utils import DEFAULT_AML_UPLOAD_DIR  # noqa: E402
 
 PYTEST_RESULTS_FILE = "pytest_results.xml"
 

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -37,7 +37,7 @@ from health_azure.utils import (  # noqa: E402
 from health_ml.utils.common_utils import DEFAULT_AML_UPLOAD_DIR  # noqa: E402
 
 PYTEST_RESULTS_FILE = "pytest_results.xml"
-PYTEST_GPU_COVERAGE_FILE = "gpu_coverage.xml"
+PYTEST_GPU_COVERAGE_FILE = "pytest_gpu_coverage.xml"
 
 
 class RunPytestConfig(param.Parameterized):

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -48,8 +48,8 @@ class RunPytestConfig(param.Parameterized):
     )
     module: str = param.String(
         default="",
-        doc="The module of tests that should be run. This value is used as an argument to --cov of pytest to run it"
-        "with coverage on the specified module.",
+        doc="The module of tests that should be run. This value is used as an argument to --cov of pytest to run code"
+        "coverage of the specified module.",
     )
     cluster: str = param.String(default="", doc="The name of the AzureML compute cluster where the script should run.")
     conda_env: str = param.String(

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -81,7 +81,7 @@ def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> No
     pytest_args = [folder_to_test, f"--junitxml={str(results_file)}"]
 
     if module_to_test:
-        pytest_args += [f"--cov={module_to_test}", "--cov-branch", "--cov-report=html" "--cov-report=xml",
+        pytest_args += [f"--cov={module_to_test}", "--cov-branch", "--cov-report=html", "--cov-report=xml",
                         "--cov-report=term-missing", "--cov-config=.coveragerc"]
     if pytest_mark:
         pytest_args += ["-m", pytest_mark]

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -131,7 +131,7 @@ def download_pytest_coverage_result(run: Run, destination_folder: Path = None) -
     logging.info(f"Downloading pytest gpu coverage file: {PYTEST_GPU_COVERAGE_FILE}")
     try:
         return download_run_output_file(Path(PYTEST_GPU_COVERAGE_FILE), destination=destination_folder, run=run)
-    except ValueError as ex:
+    except Exception as ex:
         raise ValueError(f"No pytest result file {PYTEST_GPU_COVERAGE_FILE} was found for run {run.id}") from ex
 
 

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -116,7 +116,7 @@ def download_run_output_file(blob_path: Path, destination: Path, run: Run) -> Pa
     return destination
 
 
-def download_pytest_result(run: Run, destination_folder: Path = Path.cwd()) -> Path:
+def download_pytest_coverage_result(run: Run, destination_folder: Path = Path.cwd()) -> Path:
     """
     Downloads the pytest result file that is stored in the output folder of the given AzureML run.
     If there is no pytest result file, throw an Exception.
@@ -124,11 +124,11 @@ def download_pytest_result(run: Run, destination_folder: Path = Path.cwd()) -> P
     :param destination_folder: The folder into which the PyTest result file is downloaded.
     :return: The path (folder and filename) of the downloaded file.
     """
-    logging.info(f"Downloading pytest result file: {PYTEST_RESULTS_FILE}")
+    logging.info(f"Downloading pytest gpu coverage file: {PYTEST_GPU_COVERAGE_FILE}")
     try:
-        return download_run_output_file(Path(PYTEST_RESULTS_FILE), destination=destination_folder, run=run)
+        return download_run_output_file(Path(PYTEST_GPU_COVERAGE_FILE), destination=destination_folder, run=run)
     except ValueError:
-        raise ValueError(f"No pytest result file {PYTEST_RESULTS_FILE} was found for run {run.id}")
+        raise ValueError(f"No pytest result file {PYTEST_GPU_COVERAGE_FILE} was found for run {run.id}")
 
 
 def pytest_after_submission_hook(azure_run: Run) -> None:
@@ -142,7 +142,7 @@ def pytest_after_submission_hook(azure_run: Run) -> None:
     # A build step will pick up that file and publish it to Azure DevOps.
     # If pytest_mark is set, this file must exist.
     logging.info("Downloading pytest result file.")
-    download_pytest_result(azure_run)
+    download_pytest_coverage_result(azure_run)
     if azure_run.status == RunStatus.FAILED:
         raise ValueError(f"The AzureML run failed. Please check this URL for details: " f"{azure_run.get_portal_url()}")
 

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -99,10 +99,10 @@ def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> No
 
 def download_run_output_file(blob_path: Path, destination: Path, run: Run) -> Path:
     """
-    Downloads a single file from the run's default output directory: DEFAULT_AML_UPLOAD_DIR ("outputs").
-    For example, if blobs_path = "foo/bar.csv", then the run result file "outputs/foo/bar.csv" will be downloaded
-    to <destination>/bar.csv (the directory will be stripped off).
-    :param blob_path: The name of the file to download.
+    Downloads a single file from the run's default output directory: ("outputs").
+    :param blob_path: The relative path to the file to download. For example, if blobs_path = "foo/bar.csv", then the
+    run result file "outputs/foo/bar.csv" will be downloaded to <destination>/bar.csv
+    (the directory will be stripped off).
     :param run: The AzureML run to download the files from.
     :param destination: Local path to save the downloaded blob to.
     :return: Destination path to the downloaded file(s)

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -106,7 +106,7 @@ def download_run_output_file(blob_path: Path, destination: Path, run: Run) -> Pa
     (the directory will be stripped off).
     :param run: The AzureML run to download the files from.
     :param destination: Local path to save the downloaded blob to.
-    :return: Destination path to the downloaded file(s)
+    :return: Destination path to the downloaded file(s).
     """
     blobs_prefix = str((DEFAULT_AML_UPLOAD_DIR / blob_path).as_posix())
     destination = destination / blob_path.name

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -118,7 +118,7 @@ def download_run_output_file(blob_path: Path, destination: Path, run: Run) -> Pa
     return destination
 
 
-def download_pytest_coverage_result(run: Run, destination_folder: Path = Path.cwd()) -> Path:
+def download_pytest_coverage_result(run: Run, destination_folder: Path = None) -> Path:
     """
     Downloads the pytest result file that is stored in the output folder of the given AzureML run.
     If there is no pytest result file, throw an Exception.
@@ -126,11 +126,13 @@ def download_pytest_coverage_result(run: Run, destination_folder: Path = Path.cw
     :param destination_folder: The folder into which the pytest result file is downloaded.
     :return: The path (folder and filename) of the downloaded file.
     """
+    if not destination_folder:
+        destination_folder = Path.cwd()
     logging.info(f"Downloading pytest gpu coverage file: {PYTEST_GPU_COVERAGE_FILE}")
     try:
         return download_run_output_file(Path(PYTEST_GPU_COVERAGE_FILE), destination=destination_folder, run=run)
-    except ValueError:
-        raise ValueError(f"No pytest result file {PYTEST_GPU_COVERAGE_FILE} was found for run {run.id}")
+    except ValueError as ex:
+        raise ValueError(f"No pytest result file {PYTEST_GPU_COVERAGE_FILE} was found for run {run.id}") from ex
 
 
 def pytest_after_submission_hook(azure_run: Run) -> None:

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -46,6 +46,11 @@ class RunPytestConfig(param.Parameterized):
         doc="The file or folder of tests that should be run. This value is used as the first argument to start "
         "pytest, so it can also be a specific test like 'my_test.py::any_test'",
     )
+    module: str = param.String(
+        default="",
+        doc="The module of tests that should be run. This value is used as an argument to --cov of pytest to run it"
+        "with coverage on the specified module.",
+    )
     cluster: str = param.String(default="", doc="The name of the AzureML compute cluster where the script should run.")
     conda_env: str = param.String(
         default="", doc="The path to the Conda environment file that should be used when starting pytest in AzureML."
@@ -63,7 +68,7 @@ class RunPytestConfig(param.Parameterized):
     )
 
 
-def run_pytest(folder_to_test: str, pytest_mark: str) -> None:
+def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> None:
     """
     Runs pytest on a given folder, restricting to the tests that have the given PyTest mark.
     If pytest finds no tests, or any of the tests fail, this function raises a ValueError. When run inside
@@ -73,7 +78,7 @@ def run_pytest(folder_to_test: str, pytest_mark: str) -> None:
     :param folder_to_test: The folder with tests that should be run.
     """
     results_file = Path(OUTPUT_FOLDER) / PYTEST_RESULTS_FILE
-    pytest_args = [folder_to_test, f"--junitxml={str(results_file)}"]
+    pytest_args = [folder_to_test, f"--junitxml={str(results_file)}", f"--cov={module_to_test}"]
 
     if pytest_mark:
         pytest_args += ["-m", pytest_mark]
@@ -165,4 +170,4 @@ if __name__ == "__main__":
                 max_run_duration=config.max_run_duration,
                 after_submission=pytest_after_submission_hook
             )
-    run_pytest(folder_to_test=config.folder, pytest_mark=config.mark)
+    run_pytest(folder_to_test=config.folder, pytest_mark=config.mark, module_to_test=config.module)

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -78,8 +78,11 @@ def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> No
     :param folder_to_test: The folder with tests that should be run.
     """
     results_file = Path(OUTPUT_FOLDER) / PYTEST_RESULTS_FILE
-    pytest_args = [folder_to_test, f"--junitxml={str(results_file)}", f"--cov={module_to_test}"]
+    pytest_args = [folder_to_test, f"--junitxml={str(results_file)}"]
 
+    if module_to_test:
+        pytest_args += [f"--cov={module_to_test}", "--cov-branch", "--cov-report=html" "--cov-report=xml",
+                        "--cov-report=term-missing", "--cov-config=.coveragerc"]
     if pytest_mark:
         pytest_args += ["-m", pytest_mark]
     logging.info(f"Starting pytest with these args: {pytest_args}")

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -47,11 +47,11 @@ class RunPytestConfig(param.Parameterized):
         doc="The file or folder of tests that should be run. This value is used as the first argument to start "
         "pytest, so it can also be a specific test like 'my_test.py::any_test'",
     )
-    module: str = param.String(
+    coverage_module: str = param.String(
         default="",
-        doc="The module of tests that should be run. This value is used as an argument to --cov of pytest to run code "
-        "coverage of the specified pyhton module. For example, in the subfolder hi-ml-histopathology, one can run code "
-        "coverage for the histopathology module (or SSL module) by setting `module=histopathology`.",
+        doc="This value is used as an argument to --cov of pytest to collect code coverage for the specified pyhton "
+        "module. For example, in the subfolder hi-ml-histopathology, one can collect code coverage for the "
+        "histopathology module by setting `module=histopathology`. If set to '' (default), no coverage is collected."
     )
     cluster: str = param.String(default="", doc="The name of the AzureML compute cluster where the script should run.")
     conda_env: str = param.String(
@@ -70,7 +70,7 @@ class RunPytestConfig(param.Parameterized):
     )
 
 
-def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> None:
+def run_pytest(folder_to_test: str, pytest_mark: str, coverage_module: str) -> None:
     """
     Runs pytest on a given folder, restricting to the tests that have the given pytest mark.
     If pytest finds no tests, or any of the tests fail, this function raises a ValueError. When run inside
@@ -78,13 +78,14 @@ def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> No
 
     :param pytest_mark: The pytest mark to use for filtering out the tests to run.
     :param folder_to_test: The folder with tests that should be run.
-    :param module_to_test: The module for which test code coverage should be run.
+    :param coverage_module: The module for which test code coverage should be collected. When set to empty string '', no
+        code coverage is collected.
     """
     results_file = Path(OUTPUT_FOLDER) / PYTEST_RESULTS_FILE
     pytest_args = [folder_to_test, f"--junitxml={str(results_file)}"]
 
-    if module_to_test:
-        pytest_args += [f"--cov={module_to_test}", "--cov-branch", "--cov-report=html",
+    if coverage_module:
+        pytest_args += [f"--cov={coverage_module}", "--cov-branch", "--cov-report=html",
                         f"--cov-report=xml:{OUTPUT_FOLDER}/{PYTEST_GPU_COVERAGE_FILE}",
                         "--cov-report=term-missing", "--cov-config=.coveragerc"]
     if pytest_mark:
@@ -175,4 +176,4 @@ if __name__ == "__main__":
                 max_run_duration=config.max_run_duration,
                 after_submission=pytest_after_submission_hook,
             )
-    run_pytest(folder_to_test=config.folder, pytest_mark=config.mark, module_to_test=config.module)
+    run_pytest(folder_to_test=config.folder, pytest_mark=config.mark, coverage_module=config.coverage_module)

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -7,7 +7,6 @@ import param
 from _pytest.main import ExitCode
 from azureml._restclient.constants import RunStatus
 from azureml.core import Run
-from health_ml.utils.common_utils import DEFAULT_AML_UPLOAD_DIR
 
 
 # Add hi-ml packages to sys.path so that AML can find them if we are using the runner directly from the git repo
@@ -35,6 +34,7 @@ from health_azure.utils import (  # noqa: E402
     is_running_in_azure_ml,
     parse_arguments,
 )
+from health_ml.utils.common_utils import DEFAULT_AML_UPLOAD_DIR
 
 PYTEST_RESULTS_FILE = "pytest_results.xml"
 

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -84,7 +84,7 @@ def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> No
 
     if module_to_test:
         pytest_args += [f"--cov={module_to_test}", "--cov-branch", "--cov-report=html",
-                        "--cov-report=xml::{OUTPUT_FOLDER}/{PYTEST_GPU_COVERAGE_FILE}",
+                        "--cov-report=xml:{OUTPUT_FOLDER}/{PYTEST_GPU_COVERAGE_FILE}",
                         "--cov-report=term-missing", "--cov-config=.coveragerc"]
     if pytest_mark:
         pytest_args += ["-m", pytest_mark]

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -118,7 +118,7 @@ def download_run_output_file(blob_path: Path, destination: Path, run: Run) -> Pa
     return destination
 
 
-def download_pytest_coverage_result(run: Run, destination_folder: Path = None) -> Path:
+def download_pytest_coverage_result(run: Run, destination_folder: Path = Path.cwd()) -> Path:
     """
     Downloads the pytest result file that is stored in the output folder of the given AzureML run.
     If there is no pytest result file, throw an Exception.
@@ -126,8 +126,6 @@ def download_pytest_coverage_result(run: Run, destination_folder: Path = None) -
     :param destination_folder: The folder into which the pytest result file is downloaded.
     :return: The path (folder and filename) of the downloaded file.
     """
-    if not destination_folder:
-        destination_folder = Path.cwd()
     logging.info(f"Downloading pytest gpu coverage file: {PYTEST_GPU_COVERAGE_FILE}")
     try:
         return download_run_output_file(Path(PYTEST_GPU_COVERAGE_FILE), destination=destination_folder, run=run)

--- a/hi-ml-azure/run_pytest.py
+++ b/hi-ml-azure/run_pytest.py
@@ -37,6 +37,7 @@ from health_azure.utils import (  # noqa: E402
 from health_ml.utils.common_utils import DEFAULT_AML_UPLOAD_DIR  # noqa: E402
 
 PYTEST_RESULTS_FILE = "pytest_results.xml"
+PYTEST_GPU_COVERAGE_FILE = "gpu_coverage.xml"
 
 
 class RunPytestConfig(param.Parameterized):
@@ -82,8 +83,9 @@ def run_pytest(folder_to_test: str, pytest_mark: str, module_to_test: str) -> No
     pytest_args = [folder_to_test, f"--junitxml={str(results_file)}"]
 
     if module_to_test:
-        pytest_args += [f"--cov={module_to_test}", "--cov-branch", "--cov-report=html", "--cov-report=xml",
-                        "--cov-report=term-missing", "--cov-config=.coveragerc"]
+        pytest_args += [f"--cov={module_to_test}", "--cov-branch",
+                        f"--cov-report=html:{OUTPUT_FOLDER}/{PYTEST_GPU_COVERAGE_FILE}",
+                        "--cov-report=xml", "--cov-report=term-missing", "--cov-config=.coveragerc"]
     if pytest_mark:
         pytest_args += ["-m", pytest_mark]
     logging.info(f"Starting pytest with these args: {pytest_args}")

--- a/hi-ml-histopathology/environment.yml
+++ b/hi-ml-histopathology/environment.yml
@@ -68,3 +68,4 @@ dependencies:
       - yacs==0.1.8
       # Test requirements
       - pytest==6.2.2
+      - pytest-cov==2.11.1


### PR DESCRIPTION
Add pytest_after_submission_hook to download pytest gpu test results and add it to codecov report.  