### PR TITLE
BUG: Add path resolution in dataset mounting script

### DIFF
--- a/hi-ml-histopathology/src/histopathology/scripts/mount_azure_dataset.py
+++ b/hi-ml-histopathology/src/histopathology/scripts/mount_azure_dataset.py
@@ -2,9 +2,16 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
+from pathlib import Path
+import sys
 
-from health_azure import DatasetConfig
-from health_azure.utils import get_workspace
+himl_histo_root_dir = Path(__file__).parent.parent.parent
+himl_root = himl_histo_root_dir.parent.parent
+himl_azure_package_root = himl_root / "hi-ml-azure" / "src"
+sys.path.insert(0, str(himl_azure_package_root))
+
+from health_azure import DatasetConfig  # noqa: E402
+from health_azure.utils import get_workspace  # noqa: E402
 
 
 def mount_dataset(dataset_id: str) -> str:


### PR DESCRIPTION
Add path resolution before health_azure imports in mount_azure_dataset.py script.