### PR TITLE
ENH: Pin msrest to avoid missing import

### DIFF
--- a/hi-ml-histopathology/environment.yml
+++ b/hi-ml-histopathology/environment.yml
@@ -25,6 +25,7 @@ dependencies:
       # Run requirements for hi-ml-azure
       - azureml-sdk==1.36.0
       - azureml-tensorboard==1.36.0
+      - msrest==0.6.21
       - conda-merge==0.1.5
       - param==1.12
       - pysocks==1.6.0


### PR DESCRIPTION
Related to [issue 421](https://github.com/microsoft/hi-ml/issues/421)

The latest msrest does not work with azureml-core since `SerialisationError` and `DeserializationError` have been removed from the latest