### PR TITLE
ENH: Pin cloudpickle to fix warnings in Azure ML

### DIFF
--- a/hi-ml-histopathology/environment.yml
+++ b/hi-ml-histopathology/environment.yml
@@ -25,7 +25,6 @@ dependencies:
       # Run requirements for hi-ml-azure
       - azureml-sdk==1.36.0
       - azureml-tensorboard==1.36.0
-      - msrest==0.6.21
       - conda-merge==0.1.5
       - param==1.12
       - pysocks==1.6.0
@@ -70,3 +69,6 @@ dependencies:
       # Test requirements
       - pytest==6.2.2
       - pytest-cov==2.11.1
+      # Pinned secondary dependencies to prevent clashes
+      - cloudpickle==1.6.0
+      - msrest==0.6.21


### PR DESCRIPTION
We currently have a dependency on `azureml-sdk==1.36.0`, which requires `cloudpickle<2.0.0,>=1.1.0` (specifically via the component package `azureml-dataprep`), and we also have a dependency on `mlflow==1.17.0` which depends  `mlflow` (with no upper bound). Therefore it is necessary to pin `cloudpickle` to a version which satisfies the azureml requirement, in order to fix the warnings that we currently get in Azure ML runs 

This fixes [issue 391](https://github.com/microsoft/hi-ml/issues/391)