### PR TITLE
BUG: Stop looking for environment file if already running in AML

### DIFF
--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -245,7 +245,13 @@ class Runner:
         temp_conda_file: Optional[Path] = None
         try:
             if self.experiment_config.cluster:
-                env_file = choose_conda_env_file(env_file=self.experiment_config.conda_env)
+                # Enable spawned processes to find relative env file regardless of CWD
+                conda_env_file = self.experiment_config.conda_env
+                if conda_env_file is not None:
+                    if str(self.project_root) not in str(conda_env_file):
+                        conda_env_file = self.project_root / conda_env_file
+
+                env_file = choose_conda_env_file(env_file=conda_env_file)
                 logging.info(f"Using this Conda environment definition: {env_file}")
                 check_conda_environment(env_file)
                 # This adds all pip packages required by hi-ml and hi-ml-azure in case the code is used directly from

--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -28,7 +28,7 @@ from health_azure.datasets import create_dataset_configs  # noqa: E402
 from health_azure.logging import logging_to_stdout   # noqa: E402
 from health_azure.paths import is_himl_used_from_git_repo  # noqa: E402
 from health_azure.utils import (get_workspace, is_local_rank_zero, is_running_in_azure_ml,  # noqa: E402
-                                merge_conda_files,  set_environment_variables_for_multi_node,
+                                merge_conda_files, set_environment_variables_for_multi_node,
                                 create_argparser, parse_arguments, ParserResult, apply_overrides)
 
 from health_ml.experiment_config import ExperimentConfig  # noqa: E402


### PR DESCRIPTION
Currently, if the user specifies a relative path as `--conda_env`, it will be found by the first process which will then start training, and change the cwd to 'outputs'. This means that spawned processes can't find the relative conda_env path. This PR enables spawned processes to still find the conda env path