### PR TITLE
BUG: Default parameters in `DeepSMILECRCk` container 

### DIFF
--- a/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILECrck.py
+++ b/hi-ml-histopathology/src/histopathology/configs/classification/DeepSMILECrck.py
@@ -38,7 +38,8 @@ class DeepSMILECrck(BaseMILTiles):
             num_transformer_pool_heads=4,
             encoding_chunk_size=60,
             is_finetune=False,
-            is_caching=False,
+            is_caching=True,
+            num_top_slides=0,
             # declared in DatasetParams:
             local_datasets=[Path("/tmp/datasets/TCGA-CRCk")],
             azure_datasets=["TCGA-CRCk"],


### PR DESCRIPTION
We use caching with pre-trained encoders in DeepMIL for TCGA-CRCk. This is now enabled by default in `DeepSMILECRCk` container through the `is_caching` parameter, by setting it to `True`. Also, `num_top_slides` is set to 0 by default, to avoid errors arising from caching in outputs handler for TCGA-CRCk.