### PR TITLE
ENH: Improve mypy arguments

### DIFF
--- a/hi-ml-azure/Makefile
+++ b/hi-ml-azure/Makefile
@@ -54,9 +54,9 @@ flake8: pip_test call_flake8
 
 # run mypy, assuming test requirements already installed
 call_mypy:
-	mypy --install-types --non-interactive setup.py
-	mypy --install-types --non-interactive -p health_azure
-	mypy --install-types --non-interactive -p testazure
+	mypy --install-types --show-error-codes --non-interactive setup.py
+	mypy --install-types --show-error-codes --non-interactive --package health_azure
+	mypy --install-types --show-error-codes --non-interactive --package testazure
 
 # pip install test requirements and run mypy
 mypy: pip_test call_mypy

--- a/hi-ml-histopathology/Makefile
+++ b/hi-ml-histopathology/Makefile
@@ -42,10 +42,10 @@ flake8:
 
 # run mypy, assuming test requirements already installed
 mypy:
-	mypy --install-types --non-interactive -p histopathology
-	mypy --install-types --non-interactive -p SSL
-	mypy --install-types --non-interactive -p testhisto
-	mypy --install-types --non-interactive -p testSSL
+	mypy --install-types --show-error-codes --non-interactive --package histopathology
+	mypy --install-types --show-error-codes --non-interactive --package SSL
+	mypy --install-types --show-error-codes --non-interactive --package testhisto
+	mypy --install-types --show-error-codes --non-interactive --package testSSL
 
 # run basic checks
 check: flake8 mypy

--- a/hi-ml/Makefile
+++ b/hi-ml/Makefile
@@ -53,9 +53,9 @@ flake8: pip_test call_flake8
 
 # run mypy, assuming test requirements already installed
 call_mypy:
-	mypy --install-types --non-interactive setup.py
-	mypy --install-types --non-interactive -p health_ml
-	mypy --install-types --non-interactive -p testhiml
+	mypy --install-types --show-error-codes --non-interactive setup.py
+	mypy --install-types --show-error-codes --non-interactive --package health_ml
+	mypy --install-types --show-error-codes --non-interactive --package testhiml
 
 # pip install test requirements and run mypy
 mypy: pip_test call_mypy

--- a/multimodal/Makefile
+++ b/multimodal/Makefile
@@ -39,9 +39,9 @@ flake8:
 
 # run mypy, assuming test requirements already installed
 mypy:
-	mypy --install-types --non-interactive setup.py
-	mypy --install-types --non-interactive -p health_multimodal
-	mypy --install-types --non-interactive -p test_multimodal
+	mypy --install-types --show-error-codes --non-interactive setup.py
+	mypy --install-types --show-error-codes --non-interactive --package health_multimodal
+	mypy --install-types --show-error-codes --non-interactive --package test_multimodal
 
 # run pytest on package, assuming test requirements already installed
 pytest:

--- a/new_project_template/Makefile
+++ b/new_project_template/Makefile
@@ -39,9 +39,9 @@ flake8:
 
 # run mypy, assuming test requirements already installed
 mypy:
-	mypy --install-types --non-interactive setup.py
-	mypy --install-types --non-interactive -p health_newproject
-	mypy --install-types --non-interactive -p test_newproject
+	mypy --install-types --show-error-codes --non-interactive setup.py
+	mypy --install-types --show-error-codes --non-interactive --package health_newproject
+	mypy --install-types --show-error-codes --non-interactive --package test_newproject
 
 # run pytest on package, assuming test requirements already installed
 pytest:


### PR DESCRIPTION
1. Show mypy error codes in output. That way, we can check and ignore specific errors in a readable way. For example, `# type: ignore[arg-type]` is probably better than `# type: ignore`.
1. Spell out argument name for readability