### PR TITLE
ENH: Switch from azureml-sdk to azureml-core

### DIFF
--- a/hi-ml-azure/run_requirements.txt
+++ b/hi-ml-azure/run_requirements.txt
@@ -1,5 +1,7 @@
-azureml-sdk>=1.36.0
-azureml-tensorboard>=1.36.0
+azureml-core==1.42.0.post1
+azureml-dataset-runtime[fuse]
+azureml-train-core==1.42.0
+azureml-tensorboard==1.42.0
 conda-merge>=0.1.5
 pandas>=1.3.4
 param>=1.12

--- a/hi-ml-histopathology/environment.yml
+++ b/hi-ml-histopathology/environment.yml
@@ -23,8 +23,10 @@ dependencies:
       - rpdb==0.1.6
       - setuptools==59.5.0
       # Run requirements for hi-ml-azure
-      - azureml-sdk==1.36.0
-      - azureml-tensorboard==1.36.0
+      - azureml-core==1.42.0.post1
+      - azureml-dataset-runtime[fuse]
+      - azureml-train-core==1.42.0
+      - azureml-tensorboard==1.42.0
       - conda-merge==0.1.5
       - param==1.12
       - pysocks==1.6.0


### PR DESCRIPTION
Switch from the outdated AzureML package `azureml-sdk` to `azureml-core` and `azureml-train-core`. `azureml-dataset-runtime` is required to provide local mounting.