### PR TITLE
ENH: Remove the dependency on Lightning and Lightning Bolts

### DIFF
--- a/multimodal/health_multimodal/image/__init__.py
+++ b/multimodal/health_multimodal/image/__init__.py
@@ -21,6 +21,7 @@
 
    model
    modules
+   resnet
 """
 
 from .model.model import ImageModel, ResnetType

--- a/multimodal/health_multimodal/image/model/model.py
+++ b/multimodal/health_multimodal/image/model/model.py
@@ -10,8 +10,8 @@ from typing import Any, Optional, Tuple, Union, Sequence
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from pl_bolts.models.self_supervised.resnets import resnet18, resnet50
 
+from .resnet import resnet18, resnet50
 from .modules import MLP, MultiTaskModel
 
 TypeImageEncoder = Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
@@ -118,14 +118,13 @@ class ImageEncoder(nn.Module):
         if self.img_model_type not in supported:
             raise NotImplementedError(f"Image model type \"{self.img_model_type}\" must be in {supported}")
         encoder_class = resnet18 if self.img_model_type == ResnetType.RESNET18 else resnet50
-        encoder = encoder_class(return_all_feature_maps=True, pretrained=True, **kwargs)
+        encoder = encoder_class(pretrained=True, **kwargs)
         return encoder
 
     def forward(self, x: torch.Tensor, return_patch_embeddings: bool = False) -> TypeImageEncoder:
         """Image encoder forward pass."""
 
         x = self.encoder(x)
-        x = x[-1] if isinstance(x, list) else x
         avg_pooled_emb = torch.flatten(torch.nn.functional.adaptive_avg_pool2d(x, (1, 1)), 1)
         if return_patch_embeddings:
             return x, avg_pooled_emb

--- a/multimodal/health_multimodal/image/model/resnet.py
+++ b/multimodal/health_multimodal/image/model/resnet.py
@@ -12,8 +12,8 @@ from torchvision.models.utils import load_state_dict_from_url
 
 
 class ResNetHIML(ResNet):
-    """
-    Wrapper class of the original torchvision ResNet model.
+    """Wrapper class of the original torchvision ResNet model.
+
     The forward function is updated to return the penultimate layer
     activations, which are required to obtain image patch embeddings.
     """
@@ -37,8 +37,9 @@ class ResNetHIML(ResNet):
 
 def _resnet(arch: str, block: Type[Union[BasicBlock, Bottleneck]], layers: List[int],
             pretrained: bool, progress: bool, **kwargs: Any) -> ResNetHIML:
-    """
-    Adapted from torchvision.models.resnet -- Instantiates a custom ResNet model.
+    """Instantiate a custom :class:`ResNet` model.
+
+    Adapted from :mod:`torchvision.models.resnet`.
     """
     model = ResNetHIML(block=block, layers=layers, **kwargs)
     if pretrained:
@@ -51,9 +52,8 @@ def resnet18(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
     r"""ResNet-18 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
 
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
-        progress (bool): If True, displays a progress bar of the download to stderr
+    :param pretrained: If ``True``, returns a model pre-trained on ImageNet.
+    :param progress: If ``True``, displays a progress bar of the download to ``stderr``.
     """
     return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], pretrained, progress, **kwargs)
 
@@ -62,8 +62,7 @@ def resnet50(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
     r"""ResNet-50 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
 
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
-        progress (bool): If True, displays a progress bar of the download to stderr
+    :param pretrained: If ``True``, returns a model pre-trained on ImageNet
+    :param progress: If ``True``, displays a progress bar of the download to ``stderr``.
     """
     return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], pretrained, progress, **kwargs)

--- a/multimodal/health_multimodal/image/model/resnet.py
+++ b/multimodal/health_multimodal/image/model/resnet.py
@@ -21,7 +21,7 @@ class ResNetHIML(ResNet):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
-    def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x0 = self.conv1(x)
         x0 = self.bn1(x0)
         x0 = self.relu(x0)

--- a/multimodal/health_multimodal/image/model/resnet.py
+++ b/multimodal/health_multimodal/image/model/resnet.py
@@ -1,0 +1,69 @@
+#  -------------------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+#  -------------------------------------------------------------------------------------------
+
+from typing import Any, List, Type, Union
+
+import torch
+
+from torchvision.models.resnet import model_urls, ResNet, BasicBlock, Bottleneck
+from torchvision.models.utils import load_state_dict_from_url
+
+
+class ResNetHIML(ResNet):
+    """
+    Wrapper class of the original torchvision ResNet model.
+    The forward function is updated to return the penultimate layer
+    activations, which are required to obtain image patch embeddings.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
+        x0 = self.conv1(x)
+        x0 = self.bn1(x0)
+        x0 = self.relu(x0)
+        x0 = self.maxpool(x0)
+
+        x1 = self.layer1(x0)
+        x2 = self.layer2(x1)
+        x3 = self.layer3(x2)
+        x4 = self.layer4(x3)
+
+        return x4
+
+
+def _resnet(arch: str, block: Type[Union[BasicBlock, Bottleneck]], layers: List[int],
+            pretrained: bool, progress: bool, **kwargs: Any) -> ResNetHIML:
+    """
+    Adapted from torchvision.models.resnet -- Instantiates a custom ResNet model.
+    """
+    model = ResNetHIML(block=block, layers=layers, **kwargs)
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
+        model.load_state_dict(state_dict)
+    return model
+
+
+def resnet18(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNetHIML:
+    r"""ResNet-18 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], pretrained, progress, **kwargs)
+
+
+def resnet50(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNetHIML:
+    r"""ResNet-50 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], pretrained, progress, **kwargs)

--- a/multimodal/requirements_run.txt
+++ b/multimodal/requirements_run.txt
@@ -1,8 +1,6 @@
 huggingface-hub==0.6.0
-lightning-bolts==0.3.4
 pillow==9.0.1
 pydicom==2.2.2
-pytorch-lightning==1.5.5
 scikit-image==0.18.1
 SimpleITK==2.1.1
 torch==1.9.0

--- a/multimodal/test_multimodal/image/model/test_model.py
+++ b/multimodal/test_multimodal/image/model/test_model.py
@@ -6,10 +6,10 @@
 
 import pytest
 import torch
-from pl_bolts.models.self_supervised.resnets import resnet50
 
 from health_multimodal.image.model.model import ImageEncoder, ImageModel
 from health_multimodal.image.model.modules import MultiTaskModel
+from health_multimodal.image.model.resnet import resnet50
 
 
 def test_frozen_cnn_model() -> None:
@@ -126,10 +126,9 @@ def test_reload_resnet_with_dilation() -> None:
         assert outputs_original.shape[2] * \
             2 == outputs_dilation.shape[2], "The dilation model should return larger feature maps."
 
-    expected_model = resnet50(return_all_feature_maps=True, pretrained=True,
-                              replace_stride_with_dilation=replace_stride_with_dilation)
+    expected_model = resnet50(pretrained=True, replace_stride_with_dilation=replace_stride_with_dilation)
 
     expected_model.eval()
     with torch.no_grad():
-        expected_output = expected_model(image)[-1]
+        expected_output = expected_model(image)
         assert torch.allclose(outputs_dilation, expected_output)


### PR DESCRIPTION
Addresses #464 

- Removes the dependency on pytorch-lightning and bolts.
- Wraps the torchvision resnet class to return the intermediate layer activations.
