### PR TITLE
ENH: Add commit ID when downloading CXR-BERT model

### DIFF
--- a/hi-ml-multimodal/notebooks/phrase_grounding.ipynb
+++ b/hi-ml-multimodal/notebooks/phrase_grounding.ipynb
@@ -30,13 +30,11 @@
     "import tempfile\n",
     "from pathlib import Path\n",
     "\n",
-    "from transformers import AutoModel, AutoTokenizer\n",
-    "\n",
-    "from health_multimodal.text.inference_engine import TextInferenceEngine\n",
-    "from health_multimodal.image import ImageModel, ImageInferenceEngine\n",
+    "from health_multimodal.common.visualization import plot_phrase_grounding_similarity_map\n",
+    "from health_multimodal.image import ImageInferenceEngine, ImageModel\n",
     "from health_multimodal.image.data.transforms import create_chest_xray_transform_for_inference\n",
-    "from health_multimodal.vlp.inference_engine import ImageTextInferenceEngine\n",
-    "from health_multimodal.common.visualization import plot_phrase_grounding_similarity_map"
+    "from health_multimodal.text.utils import get_cxr_bert_inference\n",
+    "from health_multimodal.vlp.inference_engine import ImageTextInferenceEngine"
    ]
   },
   {
@@ -46,11 +44,7 @@
    "outputs": [],
    "source": [
     "# Load the text inference engine\n",
-    "HUGGING_FACE_URL = \"microsoft/BiomedVLP-CXR-BERT-specialized\"\n",
-    "text_inference = TextInferenceEngine(\n",
-    "    tokenizer=AutoTokenizer.from_pretrained(HUGGING_FACE_URL, trust_remote_code=True),\n",
-    "    text_model=AutoModel.from_pretrained(HUGGING_FACE_URL, trust_remote_code=True),\n",
-    ")\n",
+    "text_inference = get_cxr_bert_inference()\n",
     "\n",
     "# Load the image inference engine\n",
     "resnet_checkpoint_path = \"\"  # add path to checkpoint here\n",
@@ -95,6 +89,13 @@
     "image_url = \"https://prod-images-static.radiopaedia.org/images/1371188/0a1f5edc85aa58d5780928cb39b08659c1fc4d6d7c7dce2f8db1d63c7c737234_gallery.jpeg\"\n",
     "plot_phrase_grounding_from_url(image_url, text_prompt)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/hi-ml-multimodal/src/health_multimodal/text/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/__init__.py
@@ -34,7 +34,8 @@
 
 from .data.io import TypePrompts
 from .inference_engine import TextInferenceEngine
-from .model.modelling_cxrbert import CXRBertConfig, CXRBertModel, CXRBertOutput
+from .model.modelling_cxrbert import CXRBertModel, CXRBertOutput
+from .model.configuration_cxrbert import CXRBertConfig, CXRBertTokenizer
 
 
 BIOMED_VLP_CXR_BERT_SPECIALIZED = "microsoft/BiomedVLP-CXR-BERT-specialized"
@@ -46,6 +47,7 @@ __all__ = [
     "TypePrompts",
     "TextInferenceEngine",
     "CXRBertConfig",
+    "CXRBertTokenizer",
     "CXRBertModel",
     "CXRBertOutput",
 ]

--- a/hi-ml-multimodal/src/health_multimodal/text/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/__init__.py
@@ -34,8 +34,10 @@ from .data.io import TypePrompts
 
 
 BIOMED_VLP_CXR_BERT_SPECIALIZED = "microsoft/BiomedVLP-CXR-BERT-specialized"
+CXR_BERT_COMMIT_ID = "3b8d69176f81b37084b653107c00e33cd08aa7c4"
 
 __all__ = [
     "BIOMED_VLP_CXR_BERT_SPECIALIZED",
+    "CXR_BERT_COMMIT_ID",
     "TypePrompts",
 ]

--- a/hi-ml-multimodal/src/health_multimodal/text/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/__init__.py
@@ -39,11 +39,11 @@ from .model.configuration_cxrbert import CXRBertConfig, CXRBertTokenizer
 
 
 BIOMED_VLP_CXR_BERT_SPECIALIZED = "microsoft/BiomedVLP-CXR-BERT-specialized"
-CXR_BERT_COMMIT_ID = "3b8d69176f81b37084b653107c00e33cd08aa7c4"
+CXR_BERT_COMMIT_TAG = "v1.0"
 
 __all__ = [
     "BIOMED_VLP_CXR_BERT_SPECIALIZED",
-    "CXR_BERT_COMMIT_ID",
+    "CXR_BERT_COMMIT_TAG",
     "TypePrompts",
     "TextInferenceEngine",
     "CXRBertConfig",

--- a/hi-ml-multimodal/src/health_multimodal/text/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/__init__.py
@@ -11,6 +11,7 @@
    :toctree:
 
    inference_engine
+   utils
 
 
 .. currentmodule:: health_multimodal.text.data
@@ -28,9 +29,12 @@
 
    configuration_cxrbert
    modelling_cxrbert
+
 """
 
 from .data.io import TypePrompts
+from .inference_engine import TextInferenceEngine
+from .model.modelling_cxrbert import CXRBertConfig, CXRBertModel, CXRBertOutput
 
 
 BIOMED_VLP_CXR_BERT_SPECIALIZED = "microsoft/BiomedVLP-CXR-BERT-specialized"
@@ -40,4 +44,8 @@ __all__ = [
     "BIOMED_VLP_CXR_BERT_SPECIALIZED",
     "CXR_BERT_COMMIT_ID",
     "TypePrompts",
+    "TextInferenceEngine",
+    "CXRBertConfig",
+    "CXRBertModel",
+    "CXRBertOutput",
 ]

--- a/hi-ml-multimodal/src/health_multimodal/text/utils.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/utils.py
@@ -6,17 +6,17 @@
 
 from typing import Tuple
 
-from health_multimodal.text import BIOMED_VLP_CXR_BERT_SPECIALIZED, CXR_BERT_COMMIT_ID
-from health_multimodal.text.inference_engine import TextInferenceEngine
-from health_multimodal.text.model.modelling_cxrbert import CXRBertModel
-from health_multimodal.text.model.configuration_cxrbert import CXRBertTokenizer
+from health_multimodal.text import (
+    BIOMED_VLP_CXR_BERT_SPECIALIZED,
+    CXR_BERT_COMMIT_ID,
+    TextInferenceEngine,
+    CXRBertModel,
+    CXRBertTokenizer,
+)
 
 
 def get_cxr_bert() -> Tuple[CXRBertTokenizer, CXRBertModel]:
-    """Loads the CXR-BERT model and tokenizer from HUGGINGFACE HUB
-       `https://huggingface.co/microsoft/BiomedVLP-CXR-BERT-specialized`
-    """
-
+    """Load the CXR-BERT model and tokenizer from the `Hugging Face Hub <https://huggingface.co/microsoft/BiomedVLP-CXR-BERT-specialized>`_."""  # noqa: E501
     model_name = BIOMED_VLP_CXR_BERT_SPECIALIZED
     revision = CXR_BERT_COMMIT_ID
     tokenizer = CXRBertTokenizer.from_pretrained(model_name, revision=revision)
@@ -25,11 +25,11 @@ def get_cxr_bert() -> Tuple[CXRBertTokenizer, CXRBertModel]:
 
 
 def get_cxr_bert_inference() -> TextInferenceEngine:
-    """Creates a TextInferenceEngine for the CXR-BERT model after downloading the model from HUGGINGFACE HUB
-       The engine can be used to get embeddings from text prompts or masked token predictions.
-    """
+    """Create a :class:`TextInferenceEngine` for the CXR-BERT model.
 
+    The model is downloaded from the Hugging Face Hub.
+    The engine can be used to get embeddings from text prompts or masked token predictions.
+    """
     tokenizer, text_model = get_cxr_bert()
     text_inference = TextInferenceEngine(tokenizer=tokenizer, text_model=text_model)
-
     return text_inference

--- a/hi-ml-multimodal/src/health_multimodal/text/utils.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/utils.py
@@ -8,7 +8,7 @@ from typing import Tuple
 
 from health_multimodal.text import (
     BIOMED_VLP_CXR_BERT_SPECIALIZED,
-    CXR_BERT_COMMIT_ID,
+    CXR_BERT_COMMIT_TAG,
     TextInferenceEngine,
     CXRBertModel,
     CXRBertTokenizer,
@@ -18,7 +18,7 @@ from health_multimodal.text import (
 def get_cxr_bert() -> Tuple[CXRBertTokenizer, CXRBertModel]:
     """Load the CXR-BERT model and tokenizer from the `Hugging Face Hub <https://huggingface.co/microsoft/BiomedVLP-CXR-BERT-specialized>`_."""  # noqa: E501
     model_name = BIOMED_VLP_CXR_BERT_SPECIALIZED
-    revision = CXR_BERT_COMMIT_ID
+    revision = CXR_BERT_COMMIT_TAG
     tokenizer = CXRBertTokenizer.from_pretrained(model_name, revision=revision)
     text_model = CXRBertModel.from_pretrained(model_name, revision=revision)
     return tokenizer, text_model

--- a/hi-ml-multimodal/src/health_multimodal/text/utils.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/utils.py
@@ -1,0 +1,29 @@
+from typing import Tuple
+
+from health_multimodal.text import BIOMED_VLP_CXR_BERT_SPECIALIZED, CXR_BERT_COMMIT_ID
+from health_multimodal.text.inference_engine import TextInferenceEngine
+from health_multimodal.text.model.modelling_cxrbert import CXRBertModel
+from health_multimodal.text.model.configuration_cxrbert import CXRBertTokenizer
+
+
+def get_cxr_bert() -> Tuple[CXRBertTokenizer, CXRBertModel]:
+    """Loads the CXR-BERT model and tokenizer from HUGGINGFACE HUB
+       `https://huggingface.co/microsoft/BiomedVLP-CXR-BERT-specialized`
+    """
+
+    model_name = BIOMED_VLP_CXR_BERT_SPECIALIZED
+    revision = CXR_BERT_COMMIT_ID
+    tokenizer = CXRBertTokenizer.from_pretrained(model_name, revision=revision)
+    text_model = CXRBertModel.from_pretrained(model_name, revision=revision)
+    return tokenizer, text_model
+
+
+def get_cxr_bert_inference() -> TextInferenceEngine:
+    """Creates a TextInferenceEngine for the CXR-BERT model after downloading the model from HUGGINGFACE HUB
+       The engine can be used to get embeddings from text prompts or masked token predictions.
+    """
+
+    tokenizer, text_model = get_cxr_bert()
+    text_inference = TextInferenceEngine(tokenizer=tokenizer, text_model=text_model)
+
+    return text_inference

--- a/hi-ml-multimodal/src/health_multimodal/text/utils.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/utils.py
@@ -1,3 +1,9 @@
+#  -------------------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+#  -------------------------------------------------------------------------------------------
+
+
 from typing import Tuple
 
 from health_multimodal.text import BIOMED_VLP_CXR_BERT_SPECIALIZED, CXR_BERT_COMMIT_ID

--- a/hi-ml-multimodal/test_multimodal/text/data/test_text_io.py
+++ b/hi-ml-multimodal/test_multimodal/text/data/test_text_io.py
@@ -4,16 +4,11 @@
 #  -------------------------------------------------------------------------------------------
 
 import pytest
-from transformers import AutoModel, AutoTokenizer
 
-from health_multimodal.text import BIOMED_VLP_CXR_BERT_SPECIALIZED, TypePrompts
-from health_multimodal.text.inference_engine import TextInferenceEngine
+from health_multimodal.text import TypePrompts
+from health_multimodal.text.utils import get_cxr_bert_inference
 
-
-text_inference = TextInferenceEngine(
-    tokenizer=AutoTokenizer.from_pretrained(BIOMED_VLP_CXR_BERT_SPECIALIZED, trust_remote_code=True),
-    text_model=AutoModel.from_pretrained(BIOMED_VLP_CXR_BERT_SPECIALIZED, trust_remote_code=True),
-)
+text_inference = get_cxr_bert_inference()
 
 
 @pytest.mark.parametrize("prompts", ("", "hello", "this is a test", ["this is", "also a test"]))

--- a/hi-ml-multimodal/test_multimodal/text/test_inference_engine.py
+++ b/hi-ml-multimodal/test_multimodal/text/test_inference_engine.py
@@ -4,22 +4,18 @@
 #  -------------------------------------------------------------------------------------------
 
 
-from typing import Tuple
-
 import pytest
 import torch
 
-from health_multimodal.text import BIOMED_VLP_CXR_BERT_SPECIALIZED
 from health_multimodal.text.inference_engine import TextInferenceEngine
-from health_multimodal.text.model.modelling_cxrbert import CXRBertModel
-from health_multimodal.text.model.configuration_cxrbert import CXRBertTokenizer
+from health_multimodal.text.utils import get_cxr_bert
 
 
 def test_text_inference_init_model_type() -> None:
     """
     Test that init fails if the wrong model type is passed in
     """
-    tokenizer, _ = _get_cxr_bert()
+    tokenizer, _ = get_cxr_bert()
     false_model = torch.nn.Linear(4, 4)
     with pytest.raises(AssertionError) as ex:
         TextInferenceEngine(tokenizer=tokenizer, text_model=false_model)  # type: ignore[arg-type]
@@ -30,7 +26,7 @@ def test_l2_normalization() -> None:
     """
     Test that the text embeddings (CLS token) are l2 normalized.
     """
-    tokenizer, text_model = _get_cxr_bert()
+    tokenizer, text_model = get_cxr_bert()
 
     text_inference = TextInferenceEngine(tokenizer=tokenizer, text_model=text_model)
     input_query = ["There is a tumor in the left lung", "Lungs are all clear"]
@@ -43,7 +39,7 @@ def test_sentence_semantic_similarity() -> None:
     """
     Test that the sentence embedding similarity computed by the text model is meaningful.
     """
-    tokenizer, text_model = _get_cxr_bert()
+    tokenizer, text_model = get_cxr_bert()
 
     # CLS token has no dedicated meaning, but we can expect vector similarity due to token overlap between the sentences
     text_inference = TextInferenceEngine(tokenizer=tokenizer, text_model=text_model)
@@ -56,19 +52,12 @@ def test_sentence_semantic_similarity() -> None:
     assert pos_sim > neg_sim_2
 
 
-def _get_cxr_bert() -> Tuple[CXRBertTokenizer, CXRBertModel]:
-    model_name = BIOMED_VLP_CXR_BERT_SPECIALIZED
-    tokenizer = CXRBertTokenizer.from_pretrained(model_name)
-    text_model = CXRBertModel.from_pretrained(model_name)
-    return tokenizer, text_model
-
-
 def test_triplet_similarities_with_inference_engine() -> None:
     """
     Test that the triplet sentence similarities computed by the text model are meaningful.
     """
 
-    tokenizer, text_model = _get_cxr_bert()
+    tokenizer, text_model = get_cxr_bert()
     text_inference = TextInferenceEngine(tokenizer=tokenizer, text_model=text_model)
 
     reference = \
@@ -102,7 +91,7 @@ def test_mlm_with_inference_engine_with_hf_hub() -> None:
     Test that the MLM model can be used with the inference engine and the filled masked tokens are correct.
     """
 
-    tokenizer, text_model = _get_cxr_bert()
+    tokenizer, text_model = get_cxr_bert()
     text_inference = TextInferenceEngine(tokenizer=tokenizer, text_model=text_model)
 
     # ##### Test Masked Language Modelling ######

--- a/hi-ml-multimodal/test_multimodal/vlp/test_vlp_inference_engine.py
+++ b/hi-ml-multimodal/test_multimodal/vlp/test_vlp_inference_engine.py
@@ -10,19 +10,11 @@ import torch
 import pytest
 import numpy as np
 from PIL import Image
-from transformers import AutoModel, AutoTokenizer
 
-from health_multimodal.text import BIOMED_VLP_CXR_BERT_SPECIALIZED
-from health_multimodal.text.inference_engine import TextInferenceEngine
+from health_multimodal.text.utils import get_cxr_bert_inference
 from health_multimodal.image import ImageModel, ResnetType, ImageInferenceEngine
 from health_multimodal.image.data.transforms import create_chest_xray_transform_for_inference
 from health_multimodal.vlp.inference_engine import ImageTextInferenceEngine
-
-
-text_inference = TextInferenceEngine(
-    tokenizer=AutoTokenizer.from_pretrained(BIOMED_VLP_CXR_BERT_SPECIALIZED, trust_remote_code=True),
-    text_model=AutoModel.from_pretrained(BIOMED_VLP_CXR_BERT_SPECIALIZED, trust_remote_code=True),
-)
 
 
 @pytest.mark.parametrize("height", (400, 500, 650))
@@ -42,7 +34,7 @@ def test_vlp_inference(height: int, query_text: str) -> None:
         transform=create_chest_xray_transform_for_inference(resize=resize, center_crop_size=center_crop_size))
     img_txt_inference = ImageTextInferenceEngine(
         image_inference_engine=image_inference,
-        text_inference_engine=text_inference,
+        text_inference_engine=get_cxr_bert_inference(),
     )
 
     with tempfile.NamedTemporaryFile(suffix='.jpg') as f:


### PR DESCRIPTION
Use the "commit hash" to pull the CXR-BERT model from HuggingFace Hub.

Closes #481 
