### PR TITLE
ENH: Exclude cache files from file watchers to speed up VSCode

### DIFF
--- a/hi-ml-azure/.vscode/settings.json
+++ b/hi-ml-azure/.vscode/settings.json
@@ -21,6 +21,12 @@
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
+    "files.watcherExclude": {
+      "**/.git/objects/**": true,
+      "**/.git/subtree-cache/**": true,
+      "**/.mypy_cache/**": true,
+      "**/.pytest_cache/**": true
+    },
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": true,

--- a/hi-ml-histopathology/.vscode/settings.json
+++ b/hi-ml-histopathology/.vscode/settings.json
@@ -21,6 +21,12 @@
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
+    "files.watcherExclude": {
+      "**/.git/objects/**": true,
+      "**/.git/subtree-cache/**": true,
+      "**/.mypy_cache/**": true,
+      "**/.pytest_cache/**": true
+    },
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": true,

--- a/hi-ml-multimodal/.vscode/settings.json
+++ b/hi-ml-multimodal/.vscode/settings.json
@@ -21,6 +21,12 @@
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
+    "files.watcherExclude": {
+      "**/.git/objects/**": true,
+      "**/.git/subtree-cache/**": true,
+      "**/.mypy_cache/**": true,
+      "**/.pytest_cache/**": true
+    },
     "python.linting.pylintEnabled": true,
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": true,

--- a/hi-ml/.vscode/settings.json
+++ b/hi-ml/.vscode/settings.json
@@ -21,6 +21,12 @@
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/.mypy_cache/**": true,
+    "**/.pytest_cache/**": true
+  },
   "python.linting.pylintEnabled": false,
   "python.linting.flake8Enabled": true,
   "python.linting.mypyEnabled": true,

--- a/himl-projects.code-workspace
+++ b/himl-projects.code-workspace
@@ -70,6 +70,12 @@
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
+    "files.watcherExclude": {
+      "**/.git/objects/**": true,
+      "**/.git/subtree-cache/**": true,
+      "**/.mypy_cache/**": true,
+      "**/.pytest_cache/**": true
+    },
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": true,


### PR DESCRIPTION
VSCode often complains that many files are slowing it down. This solution is suggested in the documentation.