### PR TITLE
ENH: Only upload codecov reports once

### DIFF
--- a/.github/workflows/cpath-pr.yml
+++ b/.github/workflows/cpath-pr.yml
@@ -102,13 +102,6 @@ jobs:
           make pip_test
           make pytest_coverage
 
-      - name: Upload coverage report to Codecov
-        # Coverage should also be uploaded if tests still fail
-        if: always()
-        uses: codecov/codecov-action@v3
-        with:
-            flags: ${{ env.folder }}
-
       - name: Run GPU tests
         # GPU tests should be run even if other tests fail
         if: always()
@@ -118,8 +111,9 @@ jobs:
           branch_name_without_prefix=${full_branch_name#$branch_prefix}
           python hi-ml-azure/run_pytest.py --mark=gpu --cluster=pr-gpu --conda_env=${{ env.folder }}/environment.yml --folder=${{ env.folder }} --coverage_module=${{ env.module_for_coverage_reporting }} --experiment="$branch_name_without_prefix"
 
-      - name: Upload gpu tests coverage report to Codecov
-        # Coverage should also be uploaded if tests still fail
+      - name: Upload coverage reports to Codecov
+        # Coverage should also be uploaded if tests still fail.
+        # This will pick up both the files coverage.xml (from the normal tests) and pytest_gpu_coverage.xml (from the GPU tests).
         if: always()
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
This avoids confusion from drop of coverage if GPU tests have not yet been accounted for.