### PR TITLE
ENH: Show run ID and prefix if no files are found

### DIFF
--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1360,7 +1360,7 @@ def _download_files_from_run(run: Run, output_dir: Path, prefix: str = "", valid
     run_paths = get_run_file_names(run, prefix=prefix)
     if len(run_paths) == 0:
         prefix_string = f' with prefix "{prefix}"' if prefix else ""
-        raise ValueError(f"No files{prefix_string} were found for run with ID {run.id}")
+        raise FileNotFoundError(f"No files{prefix_string} were found for run with ID {run.id}")
 
     for run_path in run_paths:
         output_path = output_dir / run_path

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1359,7 +1359,8 @@ def _download_files_from_run(run: Run, output_dir: Path, prefix: str = "", valid
     """
     run_paths = get_run_file_names(run, prefix=prefix)
     if len(run_paths) == 0:
-        raise ValueError("No such files were found for this Run.")
+        prefix_string = f' with prefix "{prefix}"' if prefix else ""
+        raise ValueError(f"No files{prefix_string} were found for run with ID {run.id}")
 
     for run_path in run_paths:
         output_path = output_dir / run_path


### PR DESCRIPTION
I'm getting this error on Azure ML:

```python-traceback
Traceback (most recent call last):
  File "radt5-dev/downstream_evaluation.py", line 142, in <module>
    main()
  File "radt5-dev/downstream_evaluation.py", line 138, in main
    run(args)
  File "radt5-dev/downstream_evaluation.py", line 131, in run
    results = evaluate_tasks(args)
  File "radt5-dev/downstream_evaluation.py", line 122, in evaluate_tasks
    trivial_baseline=args.trivial_baseline,
  File "radt5-dev/evaluation_utils/checkpoint.py", line 100, in get_model
    load_for_inference=True,
  File "radt5-dev/evaluation_utils/checkpoint.py", line 68, in get_pretrained_model
    workspace_config_path=azure_params.workspace_config_path)
  File "/azureml-envs/azureml_0bff92306a31e8d8ca795527d96b3826/lib/python3.7/site-packages/health_azure/utils.py", line 1035, in download_files_from_run_id
    _download_files_from_run(run, output_folder, prefix=prefix, validate_checksum=validate_checksum)
  File "/azureml-envs/azureml_0bff92306a31e8d8ca795527d96b3826/lib/python3.7/site-packages/health_azure/utils.py", line 1002, in _download_files_from_run
    raise ValueError("No such files were found for this Run.")
ValueError: No such files were found for this Run.
```

I would've liked to see which files the error is talking about. This PR should help generate a more informative error message.