### PR TITLE
ENH: Add hubconf to load models without installing

### DIFF
--- a/hi-ml-multimodal/src/health_multimodal/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/__init__.py
@@ -2,3 +2,5 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  -------------------------------------------------------------------------------------------
+
+__version__ = "0.1.0"

--- a/hi-ml-multimodal/src/health_multimodal/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/__init__.py
@@ -2,21 +2,3 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  -------------------------------------------------------------------------------------------
-
-BIOMED_VLP_CXR_BERT_SPECIALIZED = "microsoft/BiomedVLP-CXR-BERT-specialized"
-REPO_URL = f"https://huggingface.co/{BIOMED_VLP_CXR_BERT_SPECIALIZED}"
-CXR_BERT_COMMIT_TAG = "v1.1"
-
-BIOVIL_IMAGE_WEIGHTS_NAME = "biovil_image_resnet50_proj_size_128.pt"
-BIOVIL_IMAGE_WEIGHTS_URL = f"{REPO_URL}/resolve/{CXR_BERT_COMMIT_TAG}/{BIOVIL_IMAGE_WEIGHTS_NAME}"
-BIOVIL_IMAGE_WEIGHTS_MD5 = "02ce6ee460f72efd599295f440dbb453"
-
-
-__all__ = [
-    "BIOMED_VLP_CXR_BERT_SPECIALIZED",
-    "REPO_URL",
-    "CXR_BERT_COMMIT_TAG",
-    "BIOVIL_IMAGE_WEIGHTS_NAME",
-    "BIOVIL_IMAGE_WEIGHTS_URL",
-    "BIOVIL_IMAGE_WEIGHTS_MD5",
-]

--- a/hi-ml-multimodal/src/health_multimodal/image/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/__init__.py
@@ -37,6 +37,7 @@
 from .model import ImageModel
 from .model import ResnetType
 from .inference_engine import ImageInferenceEngine
+from .utils import get_biovil_resnet
 from .utils import get_biovil_resnet_inference
 
 
@@ -44,5 +45,6 @@ __all__ = [
     "ImageModel",
     "ResnetType",
     "ImageInferenceEngine",
+    "get_biovil_resnet",
     "get_biovil_resnet_inference",
 ]

--- a/hi-ml-multimodal/src/health_multimodal/image/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/__init__.py
@@ -36,8 +36,8 @@
 
 from .model import ImageModel
 from .model import ResnetType
+from .model import get_biovil_resnet
 from .inference_engine import ImageInferenceEngine
-from .utils import get_biovil_resnet
 from .utils import get_biovil_resnet_inference
 
 

--- a/hi-ml-multimodal/src/health_multimodal/image/model/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/model/__init__.py
@@ -5,9 +5,12 @@
 
 from .model import ImageModel
 from .model import ResnetType
-
+from .model import get_biovil_resnet
+from .model import CXR_BERT_COMMIT_TAG
 
 __all__ = [
     "ImageModel",
     "ResnetType",
+    "get_biovil_resnet",
+    "CXR_BERT_COMMIT_TAG",
 ]

--- a/hi-ml-multimodal/src/health_multimodal/image/model/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/model/__init__.py
@@ -7,10 +7,12 @@ from .model import ImageModel
 from .model import ResnetType
 from .model import get_biovil_resnet
 from .model import CXR_BERT_COMMIT_TAG
+from .model import BIOMED_VLP_CXR_BERT_SPECIALIZED
 
 __all__ = [
     "ImageModel",
     "ResnetType",
     "get_biovil_resnet",
     "CXR_BERT_COMMIT_TAG",
+    "BIOMED_VLP_CXR_BERT_SPECIALIZED",
 ]

--- a/hi-ml-multimodal/src/health_multimodal/image/model/resnet.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/model/resnet.py
@@ -6,12 +6,8 @@
 from typing import Any, List, Type, Union
 
 import torch
-
+from torch.hub import load_state_dict_from_url
 from torchvision.models.resnet import model_urls, ResNet, BasicBlock, Bottleneck
-try:
-    from torch.hub import load_state_dict_from_url
-except ImportError:
-    from torch.utils.model_zoo import load_url as load_state_dict_from_url
 
 
 class ResNetHIML(ResNet):

--- a/hi-ml-multimodal/src/health_multimodal/image/model/resnet.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/model/resnet.py
@@ -8,7 +8,10 @@ from typing import Any, List, Type, Union
 import torch
 
 from torchvision.models.resnet import model_urls, ResNet, BasicBlock, Bottleneck
-from torchvision.models.utils import load_state_dict_from_url
+try:
+    from torch.hub import load_state_dict_from_url
+except ImportError:
+    from torch.utils.model_zoo import load_url as load_state_dict_from_url
 
 
 class ResNetHIML(ResNet):

--- a/hi-ml-multimodal/src/health_multimodal/image/utils.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/utils.py
@@ -3,50 +3,13 @@
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  -------------------------------------------------------------------------------------------
 
-import tempfile
-from pathlib import Path
-
-from torchvision.datasets.utils import download_url
-
-from .. import BIOVIL_IMAGE_WEIGHTS_NAME
-from .. import BIOVIL_IMAGE_WEIGHTS_URL
-from .. import BIOVIL_IMAGE_WEIGHTS_MD5
-from .model import ImageModel
 from .inference_engine import ImageInferenceEngine
 from .data.transforms import create_chest_xray_transform_for_inference
+from .model import get_biovil_resnet
 
 
-MODEL_TYPE = "resnet50"
-JOINT_FEATURE_SIZE = 128
 TRANSFORM_RESIZE = 512
 TRANSFORM_CENTER_CROP_SIZE = 480
-
-
-def _download_biovil_image_model_weights() -> Path:
-    """Download image model weights from Hugging Face.
-
-    More information available at https://huggingface.co/microsoft/BiomedVLP-CXR-BERT-specialized.
-    """
-    root_dir = tempfile.gettempdir()
-    download_url(
-        BIOVIL_IMAGE_WEIGHTS_URL,
-        root=root_dir,
-        filename=BIOVIL_IMAGE_WEIGHTS_NAME,
-        md5=BIOVIL_IMAGE_WEIGHTS_MD5,
-    )
-    return Path(root_dir, BIOVIL_IMAGE_WEIGHTS_NAME)
-
-
-def get_biovil_resnet(pretrained: bool = True) -> ImageModel:
-    """Download weights from Hugging Face and instantiate the image model."""
-    resnet_checkpoint_path = _download_biovil_image_model_weights() if pretrained else None
-
-    image_model = ImageModel(
-        img_model_type=MODEL_TYPE,
-        joint_feature_size=JOINT_FEATURE_SIZE,
-        pretrained_model_path=resnet_checkpoint_path,
-    )
-    return image_model
 
 
 def get_biovil_resnet_inference() -> ImageInferenceEngine:

--- a/hi-ml-multimodal/src/health_multimodal/image/utils.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/utils.py
@@ -37,9 +37,10 @@ def _download_biovil_image_model_weights() -> Path:
     return Path(root_dir, BIOVIL_IMAGE_WEIGHTS_NAME)
 
 
-def get_biovil_resnet() -> ImageModel:
+def get_biovil_resnet(pretrained: bool = True) -> ImageModel:
     """Download weights from Hugging Face and instantiate the image model."""
-    resnet_checkpoint_path = _download_biovil_image_model_weights()
+    resnet_checkpoint_path = _download_biovil_image_model_weights() if pretrained else None
+
     image_model = ImageModel(
         img_model_type=MODEL_TYPE,
         joint_feature_size=JOINT_FEATURE_SIZE,

--- a/hi-ml-multimodal/src/health_multimodal/text/utils.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/utils.py
@@ -6,13 +6,11 @@
 
 from typing import Tuple
 
+from ..image.model import CXR_BERT_COMMIT_TAG
+from ..image.model import BIOMED_VLP_CXR_BERT_SPECIALIZED
 from .inference_engine import TextInferenceEngine
 from .model import CXRBertModel
 from .model import CXRBertTokenizer
-
-
-BIOMED_VLP_CXR_BERT_SPECIALIZED = "microsoft/BiomedVLP-CXR-BERT-specialized"
-CXR_BERT_COMMIT_TAG = "v1.1"
 
 
 def get_cxr_bert() -> Tuple[CXRBertTokenizer, CXRBertModel]:

--- a/hi-ml-multimodal/src/health_multimodal/text/utils.py
+++ b/hi-ml-multimodal/src/health_multimodal/text/utils.py
@@ -6,12 +6,13 @@
 
 from typing import Tuple
 
-from .. import BIOMED_VLP_CXR_BERT_SPECIALIZED
-from .. import CXR_BERT_COMMIT_TAG
-
 from .inference_engine import TextInferenceEngine
 from .model import CXRBertModel
 from .model import CXRBertTokenizer
+
+
+BIOMED_VLP_CXR_BERT_SPECIALIZED = "microsoft/BiomedVLP-CXR-BERT-specialized"
+CXR_BERT_COMMIT_TAG = "v1.1"
 
 
 def get_cxr_bert() -> Tuple[CXRBertTokenizer, CXRBertModel]:

--- a/hi-ml-multimodal/test_multimodal/image/model/test_model.py
+++ b/hi-ml-multimodal/test_multimodal/image/model/test_model.py
@@ -143,7 +143,7 @@ def test_hubconf() -> None:
     """Test that instantiating the image model using the PyTorch Hub is consistent with older methods."""
     image = torch.rand(1, 3, 480, 480)
 
-    github = 'microsoft/hi-ml:add-hubconf'
+    github = 'microsoft/hi-ml'
     model_hub = torch.hub.load(github, 'biovil_resnet', pretrained=True)
     model_himl = get_biovil_resnet()
 

--- a/hi-ml-multimodal/test_multimodal/image/model/test_model.py
+++ b/hi-ml-multimodal/test_multimodal/image/model/test_model.py
@@ -150,8 +150,8 @@ def test_hubconf() -> None:
     output_hub: ImageModelOutput = model_hub(image)
     output_himl: ImageModelOutput = model_himl(image)
 
-    for field_hub, field_himl in zip(fields(output_hub), fields(output_himl)):
-        value_hub = getattr(output_hub, field_hub.name)
+    for field_himl in zip(fields(output_himl)):
+        value_hub = getattr(output_hub, field_himl.name)
         value_himl = getattr(output_himl, field_himl.name)
         if value_hub is None and value_himl is None:  # for example, class_logits
             continue

--- a/hi-ml-multimodal/test_multimodal/image/model/test_model.py
+++ b/hi-ml-multimodal/test_multimodal/image/model/test_model.py
@@ -150,7 +150,7 @@ def test_hubconf() -> None:
     output_hub: ImageModelOutput = model_hub(image)
     output_himl: ImageModelOutput = model_himl(image)
 
-    for field_himl in zip(fields(output_himl)):
+    for field_himl in fields(output_himl):
         value_hub = getattr(output_hub, field_himl.name)
         value_himl = getattr(output_himl, field_himl.name)
         if value_hub is None and value_himl is None:  # for example, class_logits

--- a/hi-ml-multimodal/test_multimodal/image/model/test_model.py
+++ b/hi-ml-multimodal/test_multimodal/image/model/test_model.py
@@ -3,11 +3,15 @@
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  -------------------------------------------------------------------------------------------
 
+from dataclasses import fields
 
 import pytest
 import torch
 
-from health_multimodal.image.model.model import ImageEncoder, ImageModel
+from health_multimodal.image.model.model import ImageModel
+from health_multimodal.image.model.model import ImageEncoder
+from health_multimodal.image.model.model import ImageModelOutput
+from health_multimodal.image.model.model import get_biovil_resnet
 from health_multimodal.image.model.modules import MultiTaskModel
 from health_multimodal.image.model.resnet import resnet50
 
@@ -132,3 +136,23 @@ def test_reload_resnet_with_dilation() -> None:
     with torch.no_grad():
         expected_output = expected_model(image)
         assert torch.allclose(outputs_dilation, expected_output)
+
+
+@torch.no_grad()
+def test_hubconf() -> None:
+    """Test that instantiating the image model using the PyTorch Hub is consistent with older methods."""
+    image = torch.rand(1, 3, 480, 480)
+
+    github = 'microsoft/hi-ml:add-hubconf'
+    model_hub = torch.hub.load(github, 'biovil_resnet', pretrained=True)
+    model_himl = get_biovil_resnet()
+
+    output_hub: ImageModelOutput = model_hub(image)
+    output_himl: ImageModelOutput = model_himl(image)
+
+    for field_hub, field_himl in zip(fields(output_hub), fields(output_himl)):
+        value_hub = getattr(output_hub, field_hub.name)
+        value_himl = getattr(output_himl, field_himl.name)
+        if value_hub is None and value_himl is None:  # for example, class_logits
+            continue
+        assert torch.allclose(value_hub, value_himl)

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,11 @@
+from health_multimodal.image import ImageModel
+from health_multimodal.image import get_biovil_resnet as _biovil_resnet
+
+
+def biovil_resnet(pretrained: bool = False) -> ImageModel:
+    """Get BioViL image encoder.
+
+    :param pretrained: Load pretrained weights from a checkpoint.
+    """
+    model = _biovil_resnet(pretrained=pretrained)
+    return model

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,5 +1,5 @@
 # autopep8: off
-dependencies = ["torch", "torchvision"]
+dependencies = ["torch==1.9.0", "torchvision==0.10.0"]
 
 import sys
 from pathlib import Path

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,5 +1,15 @@
-from health_multimodal.image import ImageModel
-from health_multimodal.image import get_biovil_resnet as _biovil_resnet
+# autopep8: off
+dependencies = ["torch", "torchvision"]
+
+import sys
+from pathlib import Path
+repo_dir = Path(__file__).parent
+multimodal_src_dir = repo_dir / "hi-ml-multimodal" / "src" / "health_multimodal"
+sys.path.append(str(multimodal_src_dir))
+
+from image import ImageModel
+from image import get_biovil_resnet as _biovil_resnet
+# autopep8: on
 
 
 def biovil_resnet(pretrained: bool = False) -> ImageModel:

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,5 +1,5 @@
 # autopep8: off
-dependencies = ["torch==1.9.0", "torchvision==0.10.0"]
+dependencies = ["torch", "torchvision"]
 
 import sys
 from pathlib import Path

--- a/hubconf.py
+++ b/hubconf.py
@@ -4,11 +4,11 @@ dependencies = ["torch", "torchvision"]
 import sys
 from pathlib import Path
 repo_dir = Path(__file__).parent
-multimodal_src_dir = repo_dir / "hi-ml-multimodal" / "src" / "health_multimodal"
+multimodal_src_dir = repo_dir / "hi-ml-multimodal" / "src" / "health_multimodal" / "image"
 sys.path.append(str(multimodal_src_dir))
 
-from image import ImageModel
-from image import get_biovil_resnet as _biovil_resnet
+from model import ImageModel
+from model import get_biovil_resnet as _biovil_resnet
 # autopep8: on
 
 


### PR DESCRIPTION
This allows to run

```python
import torch
github = 'microsoft/hi-ml:add-hubconf'
model = torch.hub.load(github, 'biovil_resnet', pretrained=True)
image = torch.rand(1, 3, 480, 480)
output = model(image)
output.projected_patch_embeddings.shape  # prints torch.Size([1, 128, 15, 15])
```

It will work **even if `hi-ml-multimodal` is not installed**. Only `torch` and `torchvision` need to be installed. For that to be possible, I've had to do some not-so-nice refactoring, like declaring the same variable (Hugging Face constants) in two modules.

If this PR is merged, the snippet above won't need `:add-hubconf` and will use `main` by default.