### PR TITLE
BUG: Fix incompatibility between PIP and Conda CUDA versions

### DIFF
--- a/hi-ml-multimodal/requirements_run.txt
+++ b/hi-ml-multimodal/requirements_run.txt
@@ -4,5 +4,5 @@ pydicom==2.2.2
 scikit-image==0.18.1
 SimpleITK==2.1.1
 torch==1.9.0
-torchvision>=0.10.0,<0.10.1
+torchvision>0.9,<=0.10.0
 transformers==4.17.0

--- a/hi-ml-multimodal/requirements_run.txt
+++ b/hi-ml-multimodal/requirements_run.txt
@@ -4,5 +4,5 @@ pydicom==2.2.2
 scikit-image==0.18.1
 SimpleITK==2.1.1
 torch==1.9.0
-torchvision==0.10.0
+torchvision>=0.10.0,<0.10.1
 transformers==4.17.0


### PR DESCRIPTION
When our code in Azure DevOps tries to install `hi-ml-multimodal`

```python-traceback
Traceback (most recent call last):
[...]
  File "/azureml-envs/azureml_34426526264d358ffd2640a8d9fa6f09/lib/python3.7/site-packages/pl_bolts/utils/__init__.py", line 40, in <module>
    _TORCHVISION_LESS_THAN_0_9_1: bool = _compare_version("torchvision", operator.ge, "0.9.1")
  File "/azureml-envs/azureml_34426526264d358ffd2640a8d9fa6f09/lib/python3.7/site-packages/pl_bolts/utils/__init__.py", line 20, in _compare_version
[...]
  File "/azureml-envs/azureml_34426526264d358ffd2640a8d9fa6f09/lib/python3.7/site-packages/torchvision/extension.py", line 101, in <module>
    _check_cuda_version()
  File "/azureml-envs/azureml_34426526264d358ffd2640a8d9fa6f09/lib/python3.7/site-packages/torchvision/extension.py", line 97, in _check_cuda_version
    .format(t_major, t_minor, tv_major, tv_minor))
RuntimeError: Detected that PyTorch and torchvision were compiled with different CUDA versions. PyTorch has CUDA Version=11.1 and torchvision has CUDA Version=10.2. Please reinstall the torchvision that matches your PyTorch install.
```

It seems that `conda` installs TorchVision "`0.10.0a0`", but `0.10.0` is specified in this repo. Maybe relaxing the requirement here will help.