### PR TITLE
FIX: Hotfix HTTP error downloading model with hub

### DIFF
--- a/hi-ml-multimodal/test_multimodal/image/model/test_model.py
+++ b/hi-ml-multimodal/test_multimodal/image/model/test_model.py
@@ -143,7 +143,7 @@ def test_hubconf() -> None:
     """Test that instantiating the image model using the PyTorch Hub is consistent with older methods."""
     image = torch.rand(1, 3, 480, 480)
 
-    github = 'microsoft/hi-ml'
+    github = 'microsoft/hi-ml:main'
     model_hub = torch.hub.load(github, 'biovil_resnet', pretrained=True)
     model_himl = get_biovil_resnet()
 


### PR DESCRIPTION
Specifying the branch when downloading a model using PyTorch Hub shouldn't be necessary, but an HTTP error was being raised anyway. There seem to have been issues with this in the past:

- https://github.com/pytorch/pytorch/pull/62139
- https://github.com/pytorch/pytorch/issues/61755
- https://github.com/n2cholas/jax-resnet/issues/4
- https://github.com/pytorch/pytorch/pull/61761

Explicitly specifying `main` seems to help, so I'm adding it to the test, and it should be included in any future documentation, just in case.