### PR TITLE
ENH: Update metrics for binary classification

### DIFF
--- a/hi-ml-cpath/src/health_cpath/models/deepmil.py
+++ b/hi-ml-cpath/src/health_cpath/models/deepmil.py
@@ -8,8 +8,11 @@ from pytorch_lightning.utilities.warnings import rank_zero_warn
 from pathlib import Path
 
 from pytorch_lightning import LightningModule
+
 from torch import Tensor, argmax, mode, nn, optim, round
-from torchmetrics import AUROC, F1, Accuracy, ConfusionMatrix, Precision, Recall, CohenKappa
+from torchmetrics import (AUROC, F1, Accuracy, ConfusionMatrix, Precision,
+                          Recall, CohenKappa, AveragePrecision, Specificity)
+
 
 from health_ml.utils import log_on_epoch
 from health_ml.deep_learning_config import OptimizerParams
@@ -154,7 +157,12 @@ class BaseDeepMILModule(LightningModule):
                                   MetricsKey.PRECISION: Precision(threshold=threshold),
                                   MetricsKey.RECALL: Recall(threshold=threshold),
                                   MetricsKey.F1: F1(threshold=threshold),
-                                  MetricsKey.CONF_MATRIX: ConfusionMatrix(num_classes=2, threshold=threshold)})
+                                  MetricsKey.CONF_MATRIX: ConfusionMatrix(num_classes=2, threshold=threshold),
+                                  # Average precision is a measure of area under the PR curve
+                                  # https://sanchom.wordpress.com/tag/average-precision/
+                                  MetricsKey.AVERAGE_PRECISION: AveragePrecision(num_classes=self.n_classes),
+                                  MetricsKey.COHENKAPPA: CohenKappa(num_classes=self.n_classes, weights='quadratic'),
+                                  MetricsKey.SPECIFICITY: Specificity(num_classes=self.n_classes)})
 
     def log_metrics(self, stage: str) -> None:
         valid_stages = [stage for stage in ModelKey]

--- a/hi-ml-cpath/src/health_cpath/utils/naming.py
+++ b/hi-ml-cpath/src/health_cpath/utils/naming.py
@@ -71,6 +71,8 @@ class MetricsKey(str, Enum):
     RECALL = 'recall'
     F1 = 'f1score'
     COHENKAPPA = 'cohenkappa'
+    AVERAGE_PRECISION = 'average_precision'
+    SPECIFICITY = 'specificity'
 
 
 class ModelKey(str, Enum):


### PR DESCRIPTION
In this PR, `Average Precision`, `Specificity`, and `Cohen Kappa` metrics are added for the binary classification case in `deepmil.py`.