### PR TITLE
ENH: Add smoke test for flexible finetuning

### DIFF
--- a/.github/workflows/cpath-pr.yml
+++ b/.github/workflows/cpath-pr.yml
@@ -167,6 +167,22 @@ jobs:
           cd ${{ env.folder }}
           make smoke_test_crck_simclr_aml
 
+  smoke_test_crck_flexible_finetuning_aml:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Set up smoke test environment
+        id: setup-finetuning-smoke-test-environment
+        uses: ./.github/actions/prepare_smoke_test_environment
+
+      - name: smoke test
+        run: |
+          cd ${{ env.folder }}
+          make smoke_test_crck_flexible_finetuning_aml
+
   publish:
     runs-on: ubuntu-20.04
     needs: [
@@ -175,7 +191,8 @@ jobs:
       pytest,
       smoke_test_slidespandaimagenetmil,
       smoke_test_tilespandaimagenetmil,
-      smoke_test_crck_simclr_aml
+      smoke_test_crck_simclr_aml,
+      smoke_test_crck_flexible_finetuning_aml
       ]
     steps:
       - uses: actions/checkout@v3

--- a/hi-ml-cpath/Makefile
+++ b/hi-ml-cpath/Makefile
@@ -78,6 +78,7 @@ pytest_coverage:
 	pytest --cov=health_cpath --cov SSL --cov-branch --cov-report=html --cov-report=xml --cov-report=term-missing --cov-config=.coveragerc
 
 SSL_CKPT_RUN_ID_CRCK := CRCK_SimCLR_1655731022_85790606
+SRC_CKPT_RUN_ID_CRCK := TcgaCrckSSLMIL_1659618104_10061e60
 
 # Run regression tests and compare performance
 define BASE_CPATH_RUNNER_COMMAND
@@ -173,7 +174,7 @@ endef
 
 define CRCK_TUNING_ARGS
 --tune_encoder=True --tune_pooling=True --tune_classifier=True --pretrained_encoder=True \
---pretrained_pooling=True --pretrained_classifier=True --src_checkpoint=TcgaCrckSSLMIL_1659618104_10061e60
+--pretrained_pooling=True --pretrained_classifier=True --src_checkpoint=${SRC_CKPT_RUN_ID_CRCK}
 endef
 
 # The following test takes around 5 minutes

--- a/hi-ml-cpath/Makefile
+++ b/hi-ml-cpath/Makefile
@@ -215,11 +215,11 @@ smoke_test_crck_simclr_aml:
 	${CRCKSIMCLR_SMOKE_TEST_ARGS} ${AML_MULTIPLE_DEVICE_ARGS};}
 
 smoke_test_crck_flexible_finetuning_local:
-	{ ${BASE_CPATH_RUNNER_COMMAND} ${CRCKSIMCLR_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
+	{ ${BASE_CPATH_RUNNER_COMMAND} ${TCGACRCKSSLMIL_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
 	${CRCKSIMCLR_SMOKE_TEST_ARGS} ${CRCK_TUNING_ARGS};}
 
 smoke_test_crck_flexible_finetuning_aml:
-	{ ${BASE_CPATH_RUNNER_COMMAND} ${CRCKSIMCLR_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
+	{ ${BASE_CPATH_RUNNER_COMMAND} ${TCGACRCKSSLMIL_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
 	${CRCKSIMCLR_SMOKE_TEST_ARGS} ${AML_MULTIPLE_DEVICE_ARGS} ${CRCK_TUNING_ARGS};}
 
 smoke tests local: smoke_test_slidespandaimagenetmil_local smoke_test_tilespandaimagenetmil_local smoke_test_tcgacrcksslmil_local smoke_test_crck_simclr_local smoke_test_crck_flexible_finetuning_local

--- a/hi-ml-cpath/Makefile
+++ b/hi-ml-cpath/Makefile
@@ -173,7 +173,7 @@ define CRCKSIMCLR_SMOKE_TEST_ARGS
 endef
 
 define CRCK_TUNING_ARGS
---tune_encoder=True --tune_pooling=True --tune_classifier=True --pretrained_encoder=True \
+--tune_encoder=False --tune_pooling=True --tune_classifier=True --pretrained_encoder=True \
 --pretrained_pooling=True --pretrained_classifier=True --src_checkpoint=${SRC_CKPT_RUN_ID_CRCK}
 endef
 

--- a/hi-ml-cpath/Makefile
+++ b/hi-ml-cpath/Makefile
@@ -156,12 +156,7 @@ define AML_MULTIPLE_DEVICE_ARGS
 --cluster=dedicated-nc24s-v2 --wait_for_completion
 endef
 
-define DEEPSMILEPANDASLIDES_SMOKE_TEST_ARGS
---crossval_count=0 --num_top_slides=2 --num_top_tiles=2 --max_bag_size=3 \
---max_bag_size_inf=3
-endef
-
-define DEEPSMILEPANDATILES_SMOKE_TEST_ARGS
+define DEEPSMILEPANDA_SMOKE_TEST_ARGS
 --crossval_count=0 --num_top_slides=2 --num_top_tiles=2 --max_bag_size=3 \
 --max_bag_size_inf=3
 endef
@@ -174,24 +169,29 @@ define CRCKSIMCLR_SMOKE_TEST_ARGS
  --is_debug_model=True --num_workers=0
 endef
 
+def CRCK_TUNING_ARGS
+--tune_encoder=True --tune_pooling=True --tune_classifier=True --pretrained_encoder=True \
+--pretrained_pooling=True --pretrained_classifier=True --src_checkpoint=TcgaCrckSSLMIL_1659618104_10061e60
+endef
+
 # The following test takes around 5 minutes
 smoke_test_slidespandaimagenetmil_local:
 	{ ${BASE_CPATH_RUNNER_COMMAND} ${DEEPSMILEPANDASLIDES_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
-	${DEEPSMILEPANDASLIDES_SMOKE_TEST_ARGS};}
+	${DEEPSMILEPANDA_SMOKE_TEST_ARGS};}
 
 # Once running in AML the following test takes around 6 minutes
 smoke_test_slidespandaimagenetmil_aml:
 	{ ${BASE_CPATH_RUNNER_COMMAND} ${DEEPSMILEPANDASLIDES_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
-	${DEEPSMILEPANDASLIDES_SMOKE_TEST_ARGS} ${AML_MULTIPLE_DEVICE_ARGS};}
+	${DEEPSMILEPANDA_SMOKE_TEST_ARGS} ${AML_MULTIPLE_DEVICE_ARGS};}
 
 # The following test takes about 6 minutes
 smoke_test_tilespandaimagenetmil_local:
 	{ ${BASE_CPATH_RUNNER_COMMAND} ${DEEPSMILEPANDATILES_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
-	${DEEPSMILEPANDATILES_SMOKE_TEST_ARGS};}
+	${DEEPSMILEPANDA_SMOKE_TEST_ARGS};}
 
 smoke_test_tilespandaimagenetmil_aml:
 	{ ${BASE_CPATH_RUNNER_COMMAND} ${DEEPSMILEPANDATILES_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
-	${DEEPSMILEPANDATILES_SMOKE_TEST_ARGS}  ${AML_MULTIPLE_DEVICE_ARGS};}
+	${DEEPSMILEPANDA_SMOKE_TEST_ARGS}  ${AML_MULTIPLE_DEVICE_ARGS};}
 
 # Note: this test doesn't currently run in hi-ml Workspace since the checkpoint run specified in run_ids
 # innereye_ssl_checkpoint_crck_4ws does not exist there. Once we can specify alternative checkpoints
@@ -214,6 +214,14 @@ smoke_test_crck_simclr_aml:
 	{ ${BASE_CPATH_RUNNER_COMMAND} ${CRCKSIMCLR_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
 	${CRCKSIMCLR_SMOKE_TEST_ARGS} ${AML_MULTIPLE_DEVICE_ARGS};}
 
-smoke tests local: smoke_test_slidespandaimagenetmil_local smoke_test_tilespandaimagenetmil_local smoke_test_tcgacrcksslmil_local smoke_test_crck_simclr_local
+smoke_test_crck_flexible_finetuning_local:
+	{ ${BASE_CPATH_RUNNER_COMMAND} ${CRCKSIMCLR_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
+	${CRCKSIMCLR_SMOKE_TEST_ARGS} ${CRCK_TUNING_ARGS};}
 
-smoke tests AML: smoke_test_slidespandaimagenetmil_aml smoke_test_tilespandaimagenetmil_aml smoke_test_tcgacrcksslmil_aml smoke_test_crck_simclr_aml
+smoke_test_crck_flexible_finetuning_aml:
+	{ ${BASE_CPATH_RUNNER_COMMAND} ${CRCKSIMCLR_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
+	${CRCKSIMCLR_SMOKE_TEST_ARGS} ${AML_MULTIPLE_DEVICE_ARGS} ${CRCK_TUNING_ARGS};}
+
+smoke tests local: smoke_test_slidespandaimagenetmil_local smoke_test_tilespandaimagenetmil_local smoke_test_tcgacrcksslmil_local smoke_test_crck_simclr_local smoke_test_crck_flexible_finetuning_local
+
+smoke tests AML: smoke_test_slidespandaimagenetmil_aml smoke_test_tilespandaimagenetmil_aml smoke_test_tcgacrcksslmil_aml smoke_test_crck_simclr_aml smoke_test_crck_flexible_finetuning_aml

--- a/hi-ml-cpath/Makefile
+++ b/hi-ml-cpath/Makefile
@@ -216,11 +216,11 @@ smoke_test_crck_simclr_aml:
 
 smoke_test_crck_flexible_finetuning_local:
 	{ ${BASE_CPATH_RUNNER_COMMAND} ${TCGACRCKSSLMIL_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
-	${CRCKSIMCLR_SMOKE_TEST_ARGS} ${CRCK_TUNING_ARGS};}
+	${TCGACRCKSSLMIL_SMOKE_TEST_ARGS} ${CRCK_TUNING_ARGS};}
 
 smoke_test_crck_flexible_finetuning_aml:
 	{ ${BASE_CPATH_RUNNER_COMMAND} ${TCGACRCKSSLMIL_ARGS} ${DEFAULT_SMOKE_TEST_ARGS} \
-	${CRCKSIMCLR_SMOKE_TEST_ARGS} ${AML_MULTIPLE_DEVICE_ARGS} ${CRCK_TUNING_ARGS};}
+	${TCGACRCKSSLMIL_SMOKE_TEST_ARGS} ${AML_MULTIPLE_DEVICE_ARGS} ${CRCK_TUNING_ARGS};}
 
 smoke tests local: smoke_test_slidespandaimagenetmil_local smoke_test_tilespandaimagenetmil_local smoke_test_tcgacrcksslmil_local smoke_test_crck_simclr_local smoke_test_crck_flexible_finetuning_local
 

--- a/hi-ml-cpath/Makefile
+++ b/hi-ml-cpath/Makefile
@@ -169,7 +169,7 @@ define CRCKSIMCLR_SMOKE_TEST_ARGS
  --is_debug_model=True --num_workers=0
 endef
 
-def CRCK_TUNING_ARGS
+define CRCK_TUNING_ARGS
 --tune_encoder=True --tune_pooling=True --tune_classifier=True --pretrained_encoder=True \
 --pretrained_pooling=True --pretrained_classifier=True --src_checkpoint=TcgaCrckSSLMIL_1659618104_10061e60
 endef

--- a/hi-ml-cpath/src/health_cpath/models/deepmil.py
+++ b/hi-ml-cpath/src/health_cpath/models/deepmil.py
@@ -121,10 +121,12 @@ class BaseDeepMILModule(LightningModule):
         def _total_params(submodule: nn.Module) -> int:
             return sum(p.numel() for p in submodule.parameters())
 
-        if _total_params(pretrained_submodule) != _total_params(current_submodule):
+        pre_total_params = _total_params(pretrained_submodule)
+        cur_total_params = _total_params(current_submodule)
+
+        if pre_total_params != cur_total_params:
             raise ValueError(f"Submodule {submodule_name} has different number of parameters "
-                             f"({_total_params(current_submodule)} vs {_total_params(pretrained_submodule)})"
-                             "from pretrained model.")
+                             f"({cur_total_params} vs {pre_total_params}) from pretrained model.")
 
         for param, pretrained_param in zip(
             current_submodule.state_dict().values(), pretrained_submodule.state_dict().values()


### PR DESCRIPTION
Add a smoke test where all finetuning flags are switched on to make sure checkpoint loading and submodules initialization are completed properly.