### PR TITLE
ENH: Add dataframe kwargs for flexible csv read

### DIFF
--- a/hi-ml-cpath/src/health_cpath/datamodules/base_module.py
+++ b/hi-ml-cpath/src/health_cpath/datamodules/base_module.py
@@ -54,6 +54,7 @@ class HistoDataModule(LightningDataModule, Generic[_SlidesOrTilesDataset]):
         crossval_count: int = 0,
         crossval_index: int = 0,
         dataloader_kwargs: Optional[Dict[str, Any]] = None,
+        dataframe_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         :param root_path: Root directory of the source dataset.
@@ -74,6 +75,7 @@ class HistoDataModule(LightningDataModule, Generic[_SlidesOrTilesDataset]):
         :param crossval_count: Number of folds to perform.
         :param crossval_index: Index of the cross validation split to be performed.
         :param dataloader_kwargs: Additional keyword arguments for the training, validation, and test dataloaders.
+        :param dataframe_kwargs: Keyword arguments to pass to `pd.read_csv()` when loading the dataset CSV.
         """
 
         super().__init__()
@@ -92,9 +94,15 @@ class HistoDataModule(LightningDataModule, Generic[_SlidesOrTilesDataset]):
         self.class_weights = self.train_dataset.get_class_weights()
         self.seed = seed
         self.dataloader_kwargs = dataloader_kwargs or {}
+        self.dataframe_kwargs = dataframe_kwargs or {}
 
     def get_splits(self) -> Tuple[_SlidesOrTilesDataset, _SlidesOrTilesDataset, _SlidesOrTilesDataset]:
         """Create the training, validation, and test datasets"""
+        raise NotImplementedError
+
+    def _get_dataloader(
+        self, dataset: _SlidesOrTilesDataset, stage: ModelKey, shuffle: bool, **dataloader_kwargs: Any
+    ) -> DataLoader:
         raise NotImplementedError
 
     def train_dataloader(self) -> DataLoader:

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -50,7 +50,8 @@ class TilesDataset(Dataset):
                  train: Optional[bool] = None,
                  validate_columns: bool = True,
                  label_column: str = DEFAULT_LABEL_COLUMN,
-                 n_classes: int = 1) -> None:
+                 n_classes: int = 1,
+                 dataframe_kwargs: Optional[Dict[str, Any]] = None) -> None:
         """
         :param root: Root directory of the dataset.
         :param dataset_csv: Full path to a dataset CSV file, containing at least
@@ -65,6 +66,7 @@ class TilesDataset(Dataset):
         for this class
         :param label_column: CSV column name for tile label. Defaults to `DEFAULT_LABEL_COLUMN="label"`.
         :param n_classes: Number of classes indexed in `label_column`. Default is 1 for binary classification.
+        :param dataframe_kwargs: Keyword arguments to pass to `pd.read_csv()` when loading the dataset CSV.
         """
         if self.SPLIT_COLUMN is None and train is not None:
             raise ValueError("Train/test split was specified but dataset has no split column")
@@ -77,7 +79,7 @@ class TilesDataset(Dataset):
             self.dataset_csv = None
         else:
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
-            dataset_df = pd.read_csv(self.dataset_csv)
+            dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
         dataset_df = dataset_df.set_index(self.TILE_ID_COLUMN)
         if train is None:
@@ -158,7 +160,8 @@ class SlidesDataset(Dataset):
                  train: Optional[bool] = None,
                  validate_columns: bool = True,
                  label_column: str = DEFAULT_LABEL_COLUMN,
-                 n_classes: int = 1) -> None:
+                 n_classes: int = 1,
+                 dataframe_kwargs: Optional[Dict[str, Any]] = None) -> None:
         """
         :param root: Root directory of the dataset.
         :param dataset_csv: Full path to a dataset CSV file, containing at least
@@ -173,6 +176,7 @@ class SlidesDataset(Dataset):
         for this class
         :param label_column: CSV column name for tile label. Default is `DEFAULT_LABEL_COLUMN="label"`.
         :param n_classes: Number of classes indexed in `label_column`. Default is 1 for binary classification.
+        :param dataframe_kwargs: Keyword arguments to pass to `pd.read_csv()` when loading the dataset CSV.
         """
         if self.SPLIT_COLUMN is None and train is not None:
             raise ValueError("Train/test split was specified but dataset has no split column")
@@ -185,7 +189,7 @@ class SlidesDataset(Dataset):
             self.dataset_csv = None
         else:
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
-            dataset_df = pd.read_csv(self.dataset_csv)
+            dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
         dataset_df = dataset_df.set_index(self.SLIDE_ID_COLUMN)
         if train is None:

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -51,7 +51,7 @@ class TilesDataset(Dataset):
                  validate_columns: bool = True,
                  label_column: str = DEFAULT_LABEL_COLUMN,
                  n_classes: int = 1,
-                 dataframe_kwargs: Optional[Dict[str, Any]] = None) -> None:
+                 dataframe_kwargs: Dict[str, Any] = {}) -> None:
         """
         :param root: Root directory of the dataset.
         :param dataset_csv: Full path to a dataset CSV file, containing at least
@@ -79,7 +79,6 @@ class TilesDataset(Dataset):
             self.dataset_csv = None
         else:
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
-            dataframe_kwargs = dataframe_kwargs or {}
             dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
         dataset_df = dataset_df.set_index(self.TILE_ID_COLUMN)
@@ -190,7 +189,6 @@ class SlidesDataset(Dataset):
             self.dataset_csv = None
         else:
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
-            dataframe_kwargs = dataframe_kwargs or {}
             dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
         dataset_df = dataset_df.set_index(self.SLIDE_ID_COLUMN)

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -79,6 +79,7 @@ class TilesDataset(Dataset):
             self.dataset_csv = None
         else:
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
+            dataframe_kwargs = dataframe_kwargs or {}
             dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
         dataset_df = dataset_df.set_index(self.TILE_ID_COLUMN)
@@ -189,6 +190,7 @@ class SlidesDataset(Dataset):
             self.dataset_csv = None
         else:
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
+            dataframe_kwargs = dataframe_kwargs or {}
             dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
         dataset_df = dataset_df.set_index(self.SLIDE_ID_COLUMN)

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -161,7 +161,7 @@ class SlidesDataset(Dataset):
                  validate_columns: bool = True,
                  label_column: str = DEFAULT_LABEL_COLUMN,
                  n_classes: int = 1,
-                 dataframe_kwargs: Optional[Dict[str, Any]] = None) -> None:
+                 dataframe_kwargs: Dict[str, Any] = {}) -> None:
         """
         :param root: Root directory of the dataset.
         :param dataset_csv: Full path to a dataset CSV file, containing at least


### PR DESCRIPTION
Add `dataframe_kwargs` to BaseDatasets and HistoDatamodule to be able to read only subset of csv and custom datatype