### PR TITLE
BUG: Set dataframe index column only when necessary

### DIFF
--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -81,7 +81,7 @@ class TilesDataset(Dataset):
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
             dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
-        if isinstance(dataset_df.index, pd.RangeIndex):
+        if dataset_df.index.name != self.TILE_ID_COLUMN:
             dataset_df = dataset_df.set_index(self.TILE_ID_COLUMN)
         if train is None:
             self.dataset_df = dataset_df
@@ -192,7 +192,7 @@ class SlidesDataset(Dataset):
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
             dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
-        if isinstance(dataset_df.index, pd.RangeIndex):
+        if dataset_df.index.name != self.SLIDE_ID_COLUMN:
             dataset_df = dataset_df.set_index(self.SLIDE_ID_COLUMN)
         if train is None:
             self.dataset_df = dataset_df

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -81,7 +81,8 @@ class TilesDataset(Dataset):
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
             dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
-        dataset_df = dataset_df.set_index(self.TILE_ID_COLUMN)
+        if isinstance(dataset_df.index, pd.RangeIndex):
+            dataset_df = dataset_df.set_index(self.TILE_ID_COLUMN)
         if train is None:
             self.dataset_df = dataset_df
         else:
@@ -191,7 +192,8 @@ class SlidesDataset(Dataset):
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
             dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
 
-        dataset_df = dataset_df.set_index(self.SLIDE_ID_COLUMN)
+        if isinstance(dataset_df.index, pd.RangeIndex):
+            dataset_df = dataset_df.set_index(self.SLIDE_ID_COLUMN)
         if train is None:
             self.dataset_df = dataset_df
         else:


### PR DESCRIPTION
Index datasets dataframe by tile_id or slide_id only when necessary (e.g. the current index is not already to tile_id or slide_id  columns)