### PR TITLE
ENH: Add debug_ddp flag

### DIFF
--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -39,6 +39,7 @@ logger.setLevel(logging.DEBUG)
 
 AML_IGNORE_FILE = ".amlignore"
 AZUREML_COMMANDLINE_FLAG = "--azureml"
+DEBUG_DDP_COMMANDLINE_FLAG = "--debug_ddp"
 CONDA_ENVIRONMENT_FILE = "environment.yml"
 LOGS_FOLDER = "logs"
 OUTPUT_FOLDER = "outputs"
@@ -447,6 +448,8 @@ def submit_to_azure_if_needed(  # type: ignore
                                                       default_datastore_name=default_datastore)
     cleaned_output_datasets = _replace_string_datasets(output_datasets or [],
                                                        default_datastore_name=default_datastore)
+    if DEBUG_DDP_COMMANDLINE_FLAG in sys.argv[1:]:
+        environment_variables["TORCH_DISTRIBUTED_DEBUG"] = "DETAIL"
     # The present function will most likely be called from the script once it is running in AzureML.
     # The '--azureml' flag will not be present anymore, but we don't want to rely on that. From Run.get_context we
     # can infer if the present code is running in AzureML.

--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -39,7 +39,6 @@ logger.setLevel(logging.DEBUG)
 
 AML_IGNORE_FILE = ".amlignore"
 AZUREML_COMMANDLINE_FLAG = "--azureml"
-DEBUG_DDP_COMMANDLINE_FLAG = "--debug_ddp"
 CONDA_ENVIRONMENT_FILE = "environment.yml"
 LOGS_FOLDER = "logs"
 OUTPUT_FOLDER = "outputs"
@@ -448,9 +447,6 @@ def submit_to_azure_if_needed(  # type: ignore
                                                       default_datastore_name=default_datastore)
     cleaned_output_datasets = _replace_string_datasets(output_datasets or [],
                                                        default_datastore_name=default_datastore)
-    if DEBUG_DDP_COMMANDLINE_FLAG in sys.argv[1:]:
-        environment_variables = environment_variables or {}
-        environment_variables["TORCH_DISTRIBUTED_DEBUG"] = "DETAIL"
     # The present function will most likely be called from the script once it is running in AzureML.
     # The '--azureml' flag will not be present anymore, but we don't want to rely on that. From Run.get_context we
     # can infer if the present code is running in AzureML.

--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -449,6 +449,7 @@ def submit_to_azure_if_needed(  # type: ignore
     cleaned_output_datasets = _replace_string_datasets(output_datasets or [],
                                                        default_datastore_name=default_datastore)
     if DEBUG_DDP_COMMANDLINE_FLAG in sys.argv[1:]:
+        environment_variables = environment_variables or {}
         environment_variables["TORCH_DISTRIBUTED_DEBUG"] = "DETAIL"
     # The present function will most likely be called from the script once it is running in AzureML.
     # The '--azureml' flag will not be present anymore, but we don't want to rely on that. From Run.get_context we

--- a/hi-ml/src/health_ml/experiment_config.py
+++ b/hi-ml/src/health_ml/experiment_config.py
@@ -37,7 +37,7 @@ class ExperimentConfig(param.Parameterized):
                             doc="The Conda environment file that should be used when submitting the present run to "
                                 "AzureML. If not specified, the environment file in the current folder or one of its "
                                 "parents will be used.")
-    debug_ddp: str = param.ClassSelector(default=DebugDDPOptions.OFF, class_=DebugDDPOptions,
+    debug_ddp: DebugDDPOptions = param.ClassSelector(default=DebugDDPOptions.OFF, class_=DebugDDPOptions,
                                          doc=f"Flag to override the environment variable `{DEBUG_DDP_ENV_VAR}` that "
                                              "can be used to trigger logging and collective synchronization checks to "
                                              "ensure all ranks are synchronized appropriately. Default is `OFF`. It "

--- a/hi-ml/src/health_ml/experiment_config.py
+++ b/hi-ml/src/health_ml/experiment_config.py
@@ -38,9 +38,10 @@ class ExperimentConfig(param.Parameterized):
                                 "AzureML. If not specified, the environment file in the current folder or one of its "
                                 "parents will be used.")
     debug_ddp: DebugDDPOptions = param.ClassSelector(default=DebugDDPOptions.OFF, class_=DebugDDPOptions,
-                                                     doc=f"Flag to override the environment variable `{DEBUG_DDP_ENV_VAR}` that "
-                                                     "can be used to trigger logging and collective synchronization checks to "
-                                                     "ensure all ranks are synchronized appropriately. Default is `OFF`. It "
-                                                     "can be set to either `INFO` or `DETAIL` for different levels of logging. "
-                                                     "`DETAIL` may impact the application performance and thus should only be "
-                                                     "used when debugging issues")
+                                                     doc=f"Flag to override the environment var {DEBUG_DDP_ENV_VAR}"
+                                                         "that can be used to trigger logging and collective "
+                                                         "synchronization checks to ensure all ranks are synchronized "
+                                                         "appropriately. Default is `OFF`. It can be set to either "
+                                                         "`INFO` or `DETAIL` for different levels of logging. "
+                                                         "`DETAIL` may impact the application performance and thus "
+                                                         "should only be used when debugging issues")

--- a/hi-ml/src/health_ml/experiment_config.py
+++ b/hi-ml/src/health_ml/experiment_config.py
@@ -38,9 +38,9 @@ class ExperimentConfig(param.Parameterized):
                                 "AzureML. If not specified, the environment file in the current folder or one of its "
                                 "parents will be used.")
     debug_ddp: DebugDDPOptions = param.ClassSelector(default=DebugDDPOptions.OFF, class_=DebugDDPOptions,
-                                         doc=f"Flag to override the environment variable `{DEBUG_DDP_ENV_VAR}` that "
-                                             "can be used to trigger logging and collective synchronization checks to "
-                                             "ensure all ranks are synchronized appropriately. Default is `OFF`. It "
-                                             "can be set to either `INFO` or `DETAIL` for different levels of logging. "
-                                             "`DETAIL` may impact the application performance and thus should only be "
-                                             "used when debugging issues")
+                                                     doc=f"Flag to override the environment variable `{DEBUG_DDP_ENV_VAR}` that "
+                                                     "can be used to trigger logging and collective synchronization checks to "
+                                                     "ensure all ranks are synchronized appropriately. Default is `OFF`. It "
+                                                     "can be set to either `INFO` or `DETAIL` for different levels of logging. "
+                                                     "`DETAIL` may impact the application performance and thus should only be "
+                                                     "used when debugging issues")

--- a/hi-ml/src/health_ml/experiment_config.py
+++ b/hi-ml/src/health_ml/experiment_config.py
@@ -27,3 +27,9 @@ class ExperimentConfig(param.Parameterized):
                             doc="The Conda environment file that should be used when submitting the present run to "
                                 "AzureML. If not specified, the environment file in the current folder or one of its "
                                 "parents will be used.")
+    debug_ddp: str = param.String(default="OFF",
+                                  doc="Flag to override the environment variable `TORCH_DISTRIBUTED_DEBUG` that can be "
+                                      "used to trigger logging and collective synchronization checks to ensure all "
+                                      "ranks are synchronized appropriately. Default is `OFF`. Can be set to either "
+                                      "`INFO` or `DETAIL` for different levels of logging. `DETAIL` may impact the "
+                                      "application performance and thus should only be used when debugging issues")

--- a/hi-ml/src/health_ml/experiment_config.py
+++ b/hi-ml/src/health_ml/experiment_config.py
@@ -1,6 +1,16 @@
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 import param
+
+
+class DebugDDPOptions(Enum):
+    OFF = "OFF"
+    INFO = "INFO"
+    DETAIL = "DETAIL"
+
+
+DEBUG_DDP_ENV_VAR = "TORCH_DISTRIBUTED_DEBUG"
 
 
 class ExperimentConfig(param.Parameterized):
@@ -27,9 +37,10 @@ class ExperimentConfig(param.Parameterized):
                             doc="The Conda environment file that should be used when submitting the present run to "
                                 "AzureML. If not specified, the environment file in the current folder or one of its "
                                 "parents will be used.")
-    debug_ddp: str = param.String(default="OFF",
-                                  doc="Flag to override the environment variable `TORCH_DISTRIBUTED_DEBUG` that can be "
-                                      "used to trigger logging and collective synchronization checks to ensure all "
-                                      "ranks are synchronized appropriately. Default is `OFF`. Can be set to either "
-                                      "`INFO` or `DETAIL` for different levels of logging. `DETAIL` may impact the "
-                                      "application performance and thus should only be used when debugging issues")
+    debug_ddp: str = param.ClassSelector(default=DebugDDPOptions.OFF, class_=DebugDDPOptions,
+                                         doc=f"Flag to override the environment variable `{DEBUG_DDP_ENV_VAR}` that "
+                                             "can be used to trigger logging and collective synchronization checks to "
+                                             "ensure all ranks are synchronized appropriately. Default is `OFF`. It "
+                                             "can be set to either `INFO` or `DETAIL` for different levels of logging. "
+                                             "`DETAIL` may impact the application performance and thus should only be "
+                                             "used when debugging issues")

--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -30,7 +30,7 @@ from health_azure.utils import (get_workspace, is_local_rank_zero, is_running_in
                                 set_environment_variables_for_multi_node,
                                 create_argparser, parse_arguments, ParserResult, apply_overrides)
 
-from health_ml.experiment_config import ExperimentConfig  # noqa: E402
+from health_ml.experiment_config import DEBUG_DDP_ENV_VAR, ExperimentConfig  # noqa: E402
 from health_ml.lightning_container import LightningContainer  # noqa: E402
 from health_ml.run_ml import MLRunner  # noqa: E402
 from health_ml.utils import fixed_paths  # noqa: E402
@@ -216,6 +216,7 @@ class Runner:
 
         # TODO: Update environment variables
         environment_variables: Dict[str, Any] = {}
+        environment_variables[DEBUG_DDP_ENV_VAR] = self.experiment_config.debug_ddp.value
 
         # Get default datastore from the provided workspace. Authentication can take a few seconds, hence only do
         # that if we are really submitting to AzureML.
@@ -281,7 +282,8 @@ class Runner:
         else:
             azure_run_info = submit_to_azure_if_needed(
                 input_datasets=input_datasets,  # type: ignore
-                submit_to_azureml=False)
+                submit_to_azureml=False,
+                environment_variables=environment_variables)
         # submit_to_azure_if_needed calls sys.exit after submitting to AzureML. We only reach this when running
         # the script locally or in AzureML.
         return azure_run_info

--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -216,7 +216,7 @@ class Runner:
 
         # TODO: Update environment variables
         environment_variables: Dict[str, Any] = {}
-        environment_variables[DEBUG_DDP_ENV_VAR] = self.experiment_config.debug_ddp.value  # type: ignore
+        environment_variables[DEBUG_DDP_ENV_VAR] = self.experiment_config.debug_ddp.value
 
         # Get default datastore from the provided workspace. Authentication can take a few seconds, hence only do
         # that if we are really submitting to AzureML.

--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -216,7 +216,7 @@ class Runner:
 
         # TODO: Update environment variables
         environment_variables: Dict[str, Any] = {}
-        environment_variables[DEBUG_DDP_ENV_VAR] = self.experiment_config.debug_ddp.value
+        environment_variables[DEBUG_DDP_ENV_VAR] = self.experiment_config.debug_ddp.value  # type: ignore
 
         # Get default datastore from the provided workspace. Authentication can take a few seconds, hence only do
         # that if we are really submitting to AzureML.

--- a/hi-ml/testhiml/testhiml/test_runner.py
+++ b/hi-ml/testhiml/testhiml/test_runner.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 import shutil
 import sys
 from pathlib import Path
-from typing import Generator, List, Optional
+from typing import Any, Dict, Generator, List, Optional
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -119,8 +119,8 @@ def test_submit_to_azureml_if_needed(mock_get_workspace: MagicMock,
                                      mock_get_env_files: MagicMock,
                                      mock_runner: Runner
                                      ) -> None:
-    def _mock_dont_submit_to_aml(input_datasets: List[DatasetConfig], submit_to_azureml: bool  # type: ignore
-                                 ) -> AzureRunInfo:
+    def _mock_dont_submit_to_aml(input_datasets: List[DatasetConfig], submit_to_azureml: bool,  # type: ignore
+                                 environment_variables: Dict[str, Any]) -> AzureRunInfo:
         datasets_input = [d.target_folder for d in input_datasets] if input_datasets else []
         return AzureRunInfo(input_datasets=datasets_input,
                             output_datasets=[],


### PR DESCRIPTION
Add debug_ddp to assign different options to `TORCH_DISTRIBUTED_DEBUG` env variable.