### PR TITLE
DOC: Use a consistent team name across all packages

### DIFF
--- a/hi-ml-azure/setup.py
+++ b/hi-ml-azure/setup.py
@@ -19,76 +19,76 @@ from setuptools import setup, find_namespace_packages  # type: ignore
 here = pathlib.Path(__file__).parent.resolve()
 
 # Get the long description from the README file
-long_description = (here / 'package_description.md').read_text(encoding='utf-8')
+long_description = (here / "package_description.md").read_text(encoding="utf-8")
 
-version = ''
+version = ""
 
 # If running from a GitHub Action then a standard set of environment variables will be
 # populated (https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables).
 # In particular, GITHUB_REF is the branch or tag ref that triggered the workflow.
-# If this was triggered by a tagged commit then GITHUB_REF will be: 'ref/tags/new_tag'.
+# If this was triggered by a tagged commit then GITHUB_REF will be: "ref/tags/new_tag".
 # Extract this tag and use it as a version string
 # See also:
 # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 # https://github.com/pypa/gh-action-pypi-publish
-GITHUB_REF_TAG_COMMIT = 'refs/tags/v'
+GITHUB_REF_TAG_COMMIT = "refs/tags/v"
 
-github_ref = os.getenv('GITHUB_REF')
+github_ref = os.getenv("GITHUB_REF")
 if github_ref and github_ref.startswith(GITHUB_REF_TAG_COMMIT):
     version = github_ref[len(GITHUB_REF_TAG_COMMIT):]
 
 # Otherwise, if running from a GitHub Action, but not a tagged commit then GITHUB_RUN_NUMBER will be populated.
 # Use this as a post release number. For example if GITHUB_RUN_NUMBER = 124 then the version string will be
-# '99.99.post124'. Although this is discouraged, see:
+# "99.99.post124". Although this is discouraged, see:
 # https://www.python.org/dev/peps/pep-0440/#post-releases
 # it is necessary here to avoid duplicate packages in Test.PyPI.
 if not version:
-    build_number = os.getenv('GITHUB_RUN_NUMBER')
+    build_number = os.getenv("GITHUB_RUN_NUMBER")
     if build_number:
         # In github workflows, tests for hi-ml pull in hi-ml-azure as a dependency. Usually, we have a condition like
         # hi-ml-azure>=0.1.5. This means that a package version from PyPi would trump the local wheels. For this reason,
         # use an extremely large version number to give the local wheel priority.
-        version = '99.991.post' + build_number
+        version = "99.991.post" + build_number
     else:
         default_random_version_number = floor(random() * 10_000_000_000)
-        version = f'99.991.post{str(default_random_version_number)}'
+        version = f"99.991.post{str(default_random_version_number)}"
 
-(here / 'package_name.txt').write_text('hi-ml-azure')
-(here / 'latest_version.txt').write_text(version)
+(here / "package_name.txt").write_text("hi-ml-azure")
+(here / "latest_version.txt").write_text(version)
 
 # Read run_requirements.txt to get install_requires
-install_requires = (here / 'run_requirements.txt').read_text().split("\n")
+install_requires = (here / "run_requirements.txt").read_text().split("\n")
 # Remove any whitespace and blank lines
 install_requires = [line.strip() for line in install_requires if line.strip()]
 
-description = 'Microsoft Health Intelligence package to elevate and monitor scripts to an AzureML workspace'
+description = "Microsoft Health Futures package to elevate and monitor scripts to an AzureML workspace"
 
 setup(
-    name='hi-ml-azure',
+    name="hi-ml-azure",
     version=version,
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/microsoft/hi-ml',
-    author="Microsoft Research Cambridge InnerEye Team ",
+    long_description_content_type="text/markdown",
+    url="https://github.com/microsoft/hi-ml",
+    author="Biomedical Imaging Team @ Microsoft Health Futures",
     author_email="innereyedev@microsoft.com",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Science/Research',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Medical Science Apps.",
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.7'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.7"
     ],
-    keywords='InnerEye, HealthIntelligence, AzureML',
-    license='MIT License',
+    keywords="Health Futures, Health Intelligence, AzureML",
+    license="MIT License",
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
     install_requires=install_requires,
     entry_points={
-        'console_scripts': [
-            'himl-tb = health_azure.himl_tensorboard:main',
-            'himl-download = health_azure.himl_download:main'
+        "console_scripts": [
+            "himl-tb = health_azure.himl_tensorboard:main",
+            "himl-download = health_azure.himl_download:main"
         ]
     }
 )

--- a/hi-ml-cpath/setup.py
+++ b/hi-ml-cpath/setup.py
@@ -19,58 +19,58 @@ from setuptools import find_namespace_packages, setup  # type: ignore
 here = pathlib.Path(__file__).parent.resolve()
 
 # Get the long description from the README file
-long_description = (here / 'README.md').read_text(encoding='utf-8')
+long_description = (here / "README.md").read_text(encoding="utf-8")
 
-version = ''
+version = ""
 
 # If running from a GitHub Action then a standard set of environment variables will be
 # populated (https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables).
 # In particular, GITHUB_REF is the branch or tag ref that triggered the workflow.
-# If this was triggered by a tagged commit then GITHUB_REF will be: 'ref/tags/new_tag'.
+# If this was triggered by a tagged commit then GITHUB_REF will be: "ref/tags/new_tag".
 # Extract this tag and use it as a version string
 # See also:
 # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 # https://github.com/pypa/gh-action-pypi-publish
-GITHUB_REF_TAG_COMMIT = 'refs/tags/v'
+GITHUB_REF_TAG_COMMIT = "refs/tags/v"
 
-github_ref = os.getenv('GITHUB_REF')
+github_ref = os.getenv("GITHUB_REF")
 if github_ref and github_ref.startswith(GITHUB_REF_TAG_COMMIT):
     version = github_ref[len(GITHUB_REF_TAG_COMMIT):]
 
 # Otherwise, if running from a GitHub Action, but not a tagged commit then GITHUB_RUN_NUMBER will be populated.
 # Use this as a post release number. For example if GITHUB_RUN_NUMBER = 124 then the version string will be
-# '99.99.post124'. Although this is discouraged, see:
+# "99.99.post124". Although this is discouraged, see:
 # https://www.python.org/dev/peps/pep-0440/#post-releases
 # it is necessary here to avoid duplicate packages in Test.PyPI.
 if not version:
-    build_number = os.getenv('GITHUB_RUN_NUMBER')
+    build_number = os.getenv("GITHUB_RUN_NUMBER")
     if build_number:
         # In github workflows, we may pull in hi-ml-multimodal as a dependency. Usually, we have a condition like
         # hi-ml-multimodal>=0.1.5. This means that a package version from PyPi would trump the local wheels. For this
         # reason, use an extremely large version number to give the local wheel priority.
-        version = '99.99.post' + build_number
+        version = "99.99.post" + build_number
     else:
         default_random_version_number = floor(random() * 10_000_000_000)
-        version = f'99.99.post{str(default_random_version_number)}'
+        version = f"99.99.post{str(default_random_version_number)}"
 
-package_name = 'hi-ml-cpath'
-(here / 'package_name.txt').write_text(package_name)
-(here / 'latest_version.txt').write_text(version)
+package_name = "hi-ml-cpath"
+(here / "package_name.txt").write_text(package_name)
+(here / "latest_version.txt").write_text(version)
 
 # Read run_requirements.txt to get install_requires
-install_requires = (here / 'requirements_run.txt').read_text().split("\n")
+install_requires = (here / "requirements_run.txt").read_text().split("\n")
 # Remove any whitespace and blank lines
 install_requires = [line.strip() for line in install_requires if line.strip()]
 
-description = 'Microsoft Health Futures package for deep learning on histopathology images'
+description = "Microsoft Health Futures package for deep learning on histopathology images"
 
 setup(
     name=package_name,
     version=version,
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/microsoft/hi-ml',
+    long_description_content_type="text/markdown",
+    url="https://github.com/microsoft/hi-ml",
     author="Biomedical Imaging Team @ Microsoft Health Futures",
     author_email="innereyedev@microsoft.com",
     classifiers=[
@@ -80,8 +80,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.7"
     ],
-    keywords='Health Futures, Health Intelligence, Computational Pathology, AzureML',
-    license='MIT License',
+    keywords="Health Futures, Health Intelligence, Computational Pathology, AzureML",
+    license="MIT License",
     packages=find_namespace_packages(where="src", include=["health_cpath.*"]),
     package_dir={"": "src"},
     include_package_data=False,

--- a/hi-ml-cpath/setup.py
+++ b/hi-ml-cpath/setup.py
@@ -71,14 +71,14 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/microsoft/hi-ml',
-    author="Microsoft Research Cambridge Medical Imaging Team ",
+    author="Biomedical Imaging Team @ Microsoft Health Futures",
     author_email="innereyedev@microsoft.com",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Science/Research',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Medical Science Apps.",
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.7'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.7"
     ],
     keywords='Health Futures, Health Intelligence, Computational Pathology, AzureML',
     license='MIT License',

--- a/hi-ml/setup.py
+++ b/hi-ml/setup.py
@@ -19,74 +19,74 @@ from setuptools import setup, find_namespace_packages  # type: ignore
 here = pathlib.Path(__file__).parent.resolve()
 
 # Get the long description from the README file
-long_description = (here / 'package_description.md').read_text(encoding='utf-8')
+long_description = (here / "package_description.md").read_text(encoding="utf-8")
 
-version = ''
+version = ""
 
 # If running from a GitHub Action then a standard set of environment variables will be
 # populated (https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables).
 # In particular, GITHUB_REF is the branch or tag ref that triggered the workflow.
-# If this was triggered by a tagged commit then GITHUB_REF will be: 'ref/tags/new_tag'.
+# If this was triggered by a tagged commit then GITHUB_REF will be: "ref/tags/new_tag".
 # Extract this tag and use it as a version string
 # See also:
 # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 # https://github.com/pypa/gh-action-pypi-publish
-GITHUB_REF_TAG_COMMIT = 'refs/tags/v'
+GITHUB_REF_TAG_COMMIT = "refs/tags/v"
 
-github_ref = os.getenv('GITHUB_REF')
+github_ref = os.getenv("GITHUB_REF")
 if github_ref and github_ref.startswith(GITHUB_REF_TAG_COMMIT):
     version = github_ref[len(GITHUB_REF_TAG_COMMIT):]
 
 # Otherwise, if running from a GitHub Action, but not a tagged commit then GITHUB_RUN_NUMBER will be populated.
 # Use this as a post release number. For example if GITHUB_RUN_NUMBER = 124 then the version string will be
-# '0.1.2.post124'. Although this is discouraged, see:
+# "0.1.2.post124". Although this is discouraged, see:
 # https://www.python.org/dev/peps/pep-0440/#post-releases
 # it is necessary here to avoid duplicate packages in Test.PyPI.
 if not version:
     # TODO: Replace this with more principled package version management for the package wheels built during local test
-    # runs, one which circumvents AzureML's apparent package caching:
-    build_number = os.getenv('GITHUB_RUN_NUMBER')
+    # runs, one which circumvents AzureML"s apparent package caching:
+    build_number = os.getenv("GITHUB_RUN_NUMBER")
     if build_number:
-        version = '0.1.1.post' + build_number
+        version = "0.1.1.post" + build_number
     else:
         default_random_version_number = floor(random() * 10_000_000_000)
-        version = f'0.1.0.post{str(default_random_version_number)}'
+        version = f"0.1.0.post{str(default_random_version_number)}"
 
-(here / 'package_name.txt').write_text('hi-ml')
-(here / 'latest_version.txt').write_text(version)
+(here / "package_name.txt").write_text("hi-ml")
+(here / "latest_version.txt").write_text(version)
 
 # Read run_requirements.txt to get install_requires
-install_requires = (here / 'run_requirements.txt').read_text().split("\n")
+install_requires = (here / "run_requirements.txt").read_text().split("\n")
 # Remove any whitespace and blank lines
 install_requires = [line.strip() for line in install_requires if line.strip()]
 
-description = 'Microsoft Health Intelligence package containing high level ML components'
+description = "Microsoft Health Futures package containing high level ML components"
 
 setup(
-    name='hi-ml',
+    name="hi-ml",
     version=version,
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/microsoft/hi-ml',
-    author="Microsoft Research Cambridge InnerEye Team ",
+    long_description_content_type="text/markdown",
+    url="https://github.com/microsoft/hi-ml",
+    author="Biomedical Imaging Team @ Microsoft Health Futures",
     author_email="innereyedev@microsoft.com",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Science/Research',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Medical Science Apps.",
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.7'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.7"
     ],
-    keywords='InnerEye, HealthIntelligence, AzureML',
-    license='MIT License',
+    keywords="Health Futures, Health Intelligence, AzureML",
+    license="MIT License",
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
     install_requires=install_requires,
     entry_points={
-        'console_scripts': [
-            'himl-runner = health_ml.runner:main'
+        "console_scripts": [
+            "himl-runner = health_ml.runner:main"
         ]
     }
 )


### PR DESCRIPTION
- Remove references to Health Intelligence from PyPi package info
- Use a consistent team name
- Use double quotes consistently in all `setup.py` files