### PR TITLE
BUG: Fix SettingWithCopyWarning and parametrize metadata validation

### DIFF
--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -229,7 +229,8 @@ class SlidesDataset(Dataset):
         )
         columns = mandatory_columns.union(optional_columns)
         # SLIDE_ID_COLUMN is used for indexing and is not in df.columns anymore
-        columns_not_found = columns - set(self.dataset_df.columns) - {None} - {self.SLIDE_ID_COLUMN}
+        # None might be in columns if SPLITS_COLUMN is None
+        columns_not_found = columns - set(self.dataset_df.columns) - {None, self.SLIDE_ID_COLUMN}
         if len(columns_not_found) > 0:
             raise ValueError(f"Expected columns '{columns_not_found}' not found in the dataframe")
 

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -160,6 +160,7 @@ class SlidesDataset(Dataset):
                  dataset_df: Optional[pd.DataFrame] = None,
                  train: Optional[bool] = None,
                  validate_columns: bool = True,
+                 validate_metadata: bool = True,
                  label_column: str = DEFAULT_LABEL_COLUMN,
                  n_classes: int = 1,
                  dataframe_kwargs: Dict[str, Any] = {}) -> None:
@@ -175,6 +176,8 @@ class SlidesDataset(Dataset):
         :param validate_columns: Whether to call `validate_columns()` at the end of `__init__()`.
         `validate_columns()` checks that the loaded data frame for the dataset contains the expected column names
         for this class
+        :param validate_metadata: Whether to include metadata columns validation in `validate_columns()`. In some cases
+        when only a subset of metadata columns is loaded via custom `dataframe_kwargs`, this can be set to `False` to avoid unnecessary checks.
         :param label_column: CSV column name for tile label. Default is `DEFAULT_LABEL_COLUMN="label"`.
         :param n_classes: Number of classes indexed in `label_column`. Default is 1 for binary classification.
         :param dataframe_kwargs: Keyword arguments to pass to `pd.read_csv()` when loading the dataset CSV.
@@ -185,6 +188,7 @@ class SlidesDataset(Dataset):
         self.root_dir = Path(root)
         self.label_column = label_column
         self.n_classes = n_classes
+        self.validate_metadata = validate_metadata
 
         if dataset_df is not None:
             self.dataset_csv = None
@@ -210,6 +214,8 @@ class SlidesDataset(Dataset):
         call `validate_columns()` after creating derived columns, for example.
         """
         columns = [self.IMAGE_COLUMN, self.label_column, self.MASK_COLUMN, self.SPLIT_COLUMN]
+        if self.validate_metadata:
+            columns.extend(list(self.METADATA_COLUMNS))
         columns_not_found = []
         for column in columns:
             if column is not None and column not in self.dataset_df.columns:

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -12,7 +12,7 @@ import torch
 from sklearn.utils.class_weight import compute_class_weight
 from torch.utils.data import Dataset
 
-from health_cpath.utils.naming import SlideKey
+from health_cpath.utils.naming import SlideKey, TileKey
 
 
 DEFAULT_TRAIN_SPLIT_LABEL = "train"  # Value used to indicate the training split in `SPLIT_COLUMN`
@@ -134,6 +134,19 @@ class TilesDataset(Dataset):
         class_weights = compute_class_weight(class_weight='balanced', classes=classes, y=slide_labels)
         return torch.as_tensor(class_weights)
 
+    def copy_coordinates_columns(self) -> None:
+        """Copy columns "left" --> "tile_x" and "top" --> "tile_y" to be consistent with TilesDataset `TILE_X_COLUMN`
+        and `TILE_Y_COLUMN`."""
+
+        if TileKey.TILE_LEFT in self.dataset_df.columns:
+            self.dataset_df = self.dataset_df.assign(
+                **{TilesDataset.TILE_X_COLUMN: self.dataset_df[TileKey.TILE_LEFT]}
+            )
+        if TileKey.TILE_TOP in self.dataset_df.columns:
+            self.dataset_df = self.dataset_df.assign(
+                **{TilesDataset.TILE_Y_COLUMN: self.dataset_df[TileKey.TILE_TOP]}
+            )
+
 
 class SlidesDataset(Dataset):
     """Base class for datasets of WSIs, iterating dictionaries of image paths and metadata.
@@ -160,7 +173,6 @@ class SlidesDataset(Dataset):
                  dataset_df: Optional[pd.DataFrame] = None,
                  train: Optional[bool] = None,
                  validate_columns: bool = True,
-                 validate_metadata: bool = True,
                  label_column: str = DEFAULT_LABEL_COLUMN,
                  n_classes: int = 1,
                  dataframe_kwargs: Dict[str, Any] = {}) -> None:
@@ -176,9 +188,6 @@ class SlidesDataset(Dataset):
         :param validate_columns: Whether to call `validate_columns()` at the end of `__init__()`.
         `validate_columns()` checks that the loaded data frame for the dataset contains the expected column names
         for this class
-        :param validate_metadata: Whether to include metadata columns validation in `validate_columns()`. In some cases
-        when only a subset of metadata columns is loaded via custom `dataframe_kwargs`, this can be set to `False` to
-        avoid unnecessary checks.
         :param label_column: CSV column name for tile label. Default is `DEFAULT_LABEL_COLUMN="label"`.
         :param n_classes: Number of classes indexed in `label_column`. Default is 1 for binary classification.
         :param dataframe_kwargs: Keyword arguments to pass to `pd.read_csv()` when loading the dataset CSV.
@@ -189,13 +198,13 @@ class SlidesDataset(Dataset):
         self.root_dir = Path(root)
         self.label_column = label_column
         self.n_classes = n_classes
-        self.validate_metadata = validate_metadata
+        self.dataframe_kwargs = dataframe_kwargs
 
         if dataset_df is not None:
             self.dataset_csv = None
         else:
             self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
-            dataset_df = pd.read_csv(self.dataset_csv, **dataframe_kwargs)
+            dataset_df = pd.read_csv(self.dataset_csv, **self.dataframe_kwargs)
 
         if dataset_df.index.name != self.SLIDE_ID_COLUMN:
             dataset_df = dataset_df.set_index(self.SLIDE_ID_COLUMN)
@@ -214,13 +223,13 @@ class SlidesDataset(Dataset):
         If the constructor is overloaded in a subclass, you can pass `validate_columns=False` and
         call `validate_columns()` after creating derived columns, for example.
         """
-        columns = [self.IMAGE_COLUMN, self.label_column, self.MASK_COLUMN, self.SPLIT_COLUMN]
-        if self.validate_metadata:
-            columns.extend(list(self.METADATA_COLUMNS))
-        columns_not_found = []
-        for column in columns:
-            if column is not None and column not in self.dataset_df.columns:
-                columns_not_found.append(column)
+        mandatory_columns = {self.IMAGE_COLUMN, self.label_column, self.MASK_COLUMN, self.SPLIT_COLUMN}
+        optional_columns = (
+            set(self.dataframe_kwargs["usecols"]) if "usecols" in self.dataframe_kwargs else set(self.METADATA_COLUMNS)
+        )
+        columns = mandatory_columns.union(optional_columns)
+        # SLIDE_ID_COLUMN is used for indexing and is not in df.columns anymore
+        columns_not_found = columns - set(self.dataset_df.columns) - {None} - {self.SLIDE_ID_COLUMN}
         if len(columns_not_found) > 0:
             raise ValueError(f"Expected columns '{columns_not_found}' not found in the dataframe")
 

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -177,7 +177,8 @@ class SlidesDataset(Dataset):
         `validate_columns()` checks that the loaded data frame for the dataset contains the expected column names
         for this class
         :param validate_metadata: Whether to include metadata columns validation in `validate_columns()`. In some cases
-        when only a subset of metadata columns is loaded via custom `dataframe_kwargs`, this can be set to `False` to avoid unnecessary checks.
+        when only a subset of metadata columns is loaded via custom `dataframe_kwargs`, this can be set to `False` to
+        avoid unnecessary checks.
         :param label_column: CSV column name for tile label. Default is `DEFAULT_LABEL_COLUMN="label"`.
         :param n_classes: Number of classes indexed in `label_column`. Default is 1 for binary classification.
         :param dataframe_kwargs: Keyword arguments to pass to `pd.read_csv()` when loading the dataset CSV.

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -209,8 +209,7 @@ class SlidesDataset(Dataset):
         If the constructor is overloaded in a subclass, you can pass `validate_columns=False` and
         call `validate_columns()` after creating derived columns, for example.
         """
-        columns = [self.IMAGE_COLUMN, self.label_column, self.MASK_COLUMN,
-                   self.SPLIT_COLUMN] + list(self.METADATA_COLUMNS)
+        columns = [self.IMAGE_COLUMN, self.label_column, self.MASK_COLUMN, self.SPLIT_COLUMN]
         columns_not_found = []
         for column in columns:
             if column is not None and column not in self.dataset_df.columns:

--- a/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
@@ -43,9 +43,9 @@ class PandaDataset(SlidesDataset):
                  dataset_df: Optional[pd.DataFrame] = None,
                  label_column: str = "isup_grade",
                  n_classes: int = 6,
-                 **kwargs: Any) -> None:
+                 dataframe_kwargs: Dict[str, Any] = {}) -> None:
         super().__init__(root, dataset_csv, dataset_df, validate_columns=False, label_column=label_column,
-                         n_classes=n_classes, **kwargs)
+                         n_classes=n_classes, **dataframe_kwargs)
         # PANDA CSV does not come with paths for image and mask files
         slide_ids = self.dataset_df.index
         self.dataset_df[self.IMAGE_COLUMN] = "train_images/" + slide_ids + ".tiff"

--- a/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
@@ -45,7 +45,7 @@ class PandaDataset(SlidesDataset):
                  n_classes: int = 6,
                  dataframe_kwargs: Dict[str, Any] = {}) -> None:
         super().__init__(root, dataset_csv, dataset_df, validate_columns=False, label_column=label_column,
-                         n_classes=n_classes, **dataframe_kwargs)
+                         n_classes=n_classes, dataframe_kwargs=dataframe_kwargs)
         # PANDA CSV does not come with paths for image and mask files
         slide_ids = self.dataset_df.index
         self.dataset_df[self.IMAGE_COLUMN] = "train_images/" + slide_ids + ".tiff"

--- a/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
@@ -42,9 +42,10 @@ class PandaDataset(SlidesDataset):
                  dataset_csv: Optional[Union[str, Path]] = None,
                  dataset_df: Optional[pd.DataFrame] = None,
                  label_column: str = "isup_grade",
-                 n_classes: int = 6) -> None:
+                 n_classes: int = 6,
+                 **kwargs: Any) -> None:
         super().__init__(root, dataset_csv, dataset_df, validate_columns=False, label_column=label_column,
-                         n_classes=n_classes)
+                         n_classes=n_classes, **kwargs)
         # PANDA CSV does not come with paths for image and mask files
         slide_ids = self.dataset_df.index
         self.dataset_df[self.IMAGE_COLUMN] = "train_images/" + slide_ids + ".tiff"

--- a/hi-ml-cpath/src/health_cpath/datasets/panda_tiles_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/panda_tiles_dataset.py
@@ -11,7 +11,6 @@ from torchvision.datasets.vision import VisionDataset
 
 from health_cpath.datasets.base_dataset import TilesDataset
 from health_cpath.models.transforms import load_pil_image
-from health_cpath.utils.naming import TileKey
 
 from health_cpath.datasets.dataset_return_index import DatasetWithReturnIndex
 
@@ -73,12 +72,7 @@ class PandaTilesDataset(TilesDataset):
             dataset_df_filtered = self.dataset_df.sample(n=df_length_random_subset_fraction)
             self.dataset_df = dataset_df_filtered
 
-        # Copy columns "left" --> "tile_x" and "top" --> "tile_y"
-        # to be consistent with TilesDataset `TILE_X_COLUMN` and `TILE_Y_COLUMN`
-        if TileKey.TILE_LEFT in self.dataset_df.columns:
-            self.dataset_df = self.dataset_df.assign(tile_x=self.dataset_df[TileKey.TILE_LEFT])
-        if TileKey.TILE_TOP in self.dataset_df.columns:
-            self.dataset_df = self.dataset_df.assign(tile_y=self.dataset_df[TileKey.TILE_TOP])
+        self.copy_coordinates_columns()
         self.validate_columns()
 
 

--- a/hi-ml-cpath/src/health_cpath/datasets/panda_tiles_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/panda_tiles_dataset.py
@@ -76,9 +76,9 @@ class PandaTilesDataset(TilesDataset):
         # Copy columns "left" --> "tile_x" and "top" --> "tile_y"
         # to be consistent with TilesDataset `TILE_X_COLUMN` and `TILE_Y_COLUMN`
         if TileKey.TILE_LEFT in self.dataset_df.columns:
-            self.dataset_df[TilesDataset.TILE_X_COLUMN] = self.dataset_df[TileKey.TILE_LEFT]
+            self.dataset_df = self.dataset_df.assign(tile_x=self.dataset_df[TileKey.TILE_LEFT])
         if TileKey.TILE_TOP in self.dataset_df.columns:
-            self.dataset_df[TilesDataset.TILE_Y_COLUMN] = self.dataset_df[TileKey.TILE_TOP]
+            self.dataset_df = self.dataset_df.assign(tile_y=self.dataset_df[TileKey.TILE_TOP])
         self.validate_columns()
 
 

--- a/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_slides.py
+++ b/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_slides.py
@@ -14,6 +14,7 @@ import torch
 from pytorch_lightning import seed_everything
 
 from health_cpath.configs.classification.DeepSMILESlidesPandaBenchmark import DeepSMILESlidesPandaBenchmark
+from health_cpath.datasets.panda_dataset import PandaDataset
 from health_cpath.utils.naming import SlideKey
 from testhisto.mocks.base_data_generator import MockHistoDataType
 from testhisto.mocks.slides_generator import MockPandaSlidesGenerator, TilesPositioningType
@@ -89,3 +90,23 @@ def test_panda_reproducibility(tmp_path: Path) -> None:
     # When using a fixed see, all 3 dataloaders should return idential items. Validation and test dataloader
     # are at present not randomized, but checking those as well just in case.
     test_data_items_are_equal(["train_dataloader", "val_dataloader", "test_dataloader"])
+
+
+def test_validate_metadata_dataframe(tmp_path: Path) -> None:
+    _ = MockPandaSlidesGenerator(
+        dest_data_path=tmp_path,
+        mock_type=MockHistoDataType.FAKE,
+        n_tiles=4,
+        n_slides=10,
+        n_channels=3,
+        n_levels=3,
+        tile_size=28,
+        background_val=255,
+        tiles_pos_type=TilesPositioningType.RANDOM,
+    )
+    dataframe_kwargs = dict(
+        usecols=[PandaDataset.SLIDE_ID_COLUMN, PandaDataset.METADATA_COLUMNS[1], PandaDataset.MASK_COLUMN]
+    )
+    with pytest.raises(ValueError, match=r"Expected columns"):
+        _ = PandaDataset(root=tmp_path, dataframe_kwargs=dataframe_kwargs, validate_metadata=True)
+    _ = PandaDataset(root=tmp_path, dataframe_kwargs=dataframe_kwargs, validate_metadata=False)

--- a/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_slides.py
+++ b/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_slides.py
@@ -92,7 +92,7 @@ def test_panda_reproducibility(tmp_path: Path) -> None:
     test_data_items_are_equal(["train_dataloader", "val_dataloader", "test_dataloader"])
 
 
-def test_validate_metadata_dataframe(tmp_path: Path) -> None:
+def test_validate_columns(tmp_path: Path) -> None:
     _ = MockPandaSlidesGenerator(
         dest_data_path=tmp_path,
         mock_type=MockHistoDataType.FAKE,
@@ -104,9 +104,7 @@ def test_validate_metadata_dataframe(tmp_path: Path) -> None:
         background_val=255,
         tiles_pos_type=TilesPositioningType.RANDOM,
     )
-    dataframe_kwargs = dict(
-        usecols=[PandaDataset.SLIDE_ID_COLUMN, PandaDataset.METADATA_COLUMNS[1], PandaDataset.MASK_COLUMN]
-    )
+    usecols = [PandaDataset.SLIDE_ID_COLUMN, PandaDataset.MASK_COLUMN]
     with pytest.raises(ValueError, match=r"Expected columns"):
-        _ = PandaDataset(root=tmp_path, dataframe_kwargs=dataframe_kwargs, validate_metadata=True)
-    _ = PandaDataset(root=tmp_path, dataframe_kwargs=dataframe_kwargs, validate_metadata=False)
+        _ = PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols})
+    _ = PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols + [PandaDataset.METADATA_COLUMNS[1]]})

--- a/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_tiles.py
+++ b/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_tiles.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import pytest
+import pandas as pd
+
+from health_cpath.datasets.panda_tiles_dataset import PandaTilesDataset
+from health_cpath.utils.naming import TileKey
+from testhisto.mocks.base_data_generator import MockHistoDataType
+from testhisto.mocks.tiles_generator import MockPandaTilesGenerator
+
+
+@pytest.mark.parametrize("version", [0, 1])
+def test_panda_tiles_dataset(version: int, tmp_path: Path) -> None:
+    """Test the PandaTilesDataset class."""
+
+    _ = MockPandaTilesGenerator(
+        dest_data_path=tmp_path,
+        mock_type=MockHistoDataType.FAKE,
+        n_tiles=4,
+        n_slides=10,
+        n_channels=3,
+        tile_size=28,
+        img_size=224,
+        version=version,
+    )
+    base_df = pd.read_csv(tmp_path / PandaTilesDataset.DEFAULT_CSV_FILENAME).set_index(PandaTilesDataset.TILE_ID_COLUMN)
+    dataset = PandaTilesDataset(root=tmp_path)
+
+    coordinates_columns_v0 = {PandaTilesDataset.TILE_X_COLUMN, PandaTilesDataset.TILE_Y_COLUMN}
+    coordinates_columns_v1 = {TileKey.TILE_LEFT, TileKey.TILE_TOP}
+    dataset_columns = set(dataset.dataset_df.columns)
+    base_df_columns = set(base_df.columns)
+
+    assert coordinates_columns_v0.issubset(dataset_columns)   # v0 columns are always present
+
+    if version == 0:
+        assert base_df_columns == dataset_columns
+        assert not coordinates_columns_v1.issubset(dataset_columns)
+    elif version == 1:
+        assert dataset_columns == base_df_columns.union(coordinates_columns_v0)
+        assert not coordinates_columns_v0.issubset(base_df_columns)

--- a/hi-ml-cpath/testhisto/testhisto/mocks/slides_generator.py
+++ b/hi-ml-cpath/testhisto/testhisto/mocks/slides_generator.py
@@ -81,9 +81,12 @@ class MockPandaSlidesGenerator(MockHistoDataGenerator):
     def create_mock_metadata_dataframe(self) -> pd.DataFrame:
         """Create a mock dataframe with random metadata."""
         isup_grades = np.tile(list(self.ISUP_GRADE_MAPPING.keys()), self.n_slides // PANDA_N_CLASSES + 1,)
-        mock_metadata: dict = {col: [] for col in [PandaDataset.SLIDE_ID_COLUMN, *PandaDataset.METADATA_COLUMNS]}
+        mock_metadata: dict = {
+            col: [] for col in [PandaDataset.SLIDE_ID_COLUMN, PandaDataset.MASK_COLUMN, *PandaDataset.METADATA_COLUMNS]
+        }
         for slide_id in range(self.n_slides):
             mock_metadata[PandaDataset.SLIDE_ID_COLUMN].append(f"_{slide_id}")
+            mock_metadata[PandaDataset.MASK_COLUMN].append(f"_{slide_id}_mask")
             mock_metadata[self.DATA_PROVIDER].append(np.random.choice(self.DATA_PROVIDERS_VALUES))
             mock_metadata[self.ISUP_GRADE].append(isup_grades[slide_id])
             mock_metadata[self.GLEASON_SCORE].append(np.random.choice(self.ISUP_GRADE_MAPPING[isup_grades[slide_id]]))

--- a/hi-ml-cpath/testhisto/testhisto/mocks/tiles_generator.py
+++ b/hi-ml-cpath/testhisto/testhisto/mocks/tiles_generator.py
@@ -17,15 +17,16 @@ from testhisto.mocks.base_data_generator import MockHistoDataGenerator, MockHist
 class MockPandaTilesGenerator(MockHistoDataGenerator):
     """Generator class to create mock tiles dataset on the fly. The tiles are positioned randomly in a wsi grid."""
 
-    def __init__(self, img_size: int = 224, version: int = 0, **kwargs: Any) -> None:
+    def __init__(self, img_size: int = 224, tiling_version: int = 0, **kwargs: Any) -> None:
         """
         :param img_size: The whole slide image resolution, defaults to 224.
-        :param version: The version of the tiles dataset, defaults to 0. This is used to support both the old and new
-        tiling scheme where coordinates are stored as tile_x and tile_y in v0 and as tile_left and tile_top in v1.
+        :param tiling_version: The version of the tiles dataset, defaults to 0. This is used to support both the old
+            and new tiling scheme where coordinates are stored as tile_x and tile_y in v0 and as tile_left and tile_top
+            in v1.
         :param kwargs: Same params passed to MockHistoDataGenerator.
         """
         self.img_size = img_size
-        self.version = version
+        self.tiling_version = tiling_version
         super().__init__(**kwargs)
 
     def validate(self) -> None:
@@ -36,12 +37,12 @@ class MockPandaTilesGenerator(MockHistoDataGenerator):
             f"The image of size {self.img_size} can't contain more than {(self.img_size // self.tile_size)**2} tiles."
             f"Choose a number of tiles 0 < n_tiles <= {(self.img_size // self.tile_size)**2} "
         )
-        assert self.version in [0, 1], f"Version should be 0 or 1, got {self.version}"
+        assert self.tiling_version in [0, 1], f"Tiling version should be 0 or 1, got {self.tiling_version}"
 
     def create_mock_metadata_dataframe(self) -> pd.DataFrame:
         """Create a mock dataframe with random metadata."""
-        x_column = TileKey.TILE_LEFT if self.version == 1 else PandaTilesDataset.TILE_X_COLUMN
-        y_column = TileKey.TILE_TOP if self.version == 1 else PandaTilesDataset.TILE_Y_COLUMN
+        x_column = TileKey.TILE_LEFT if self.tiling_version == 1 else PandaTilesDataset.TILE_X_COLUMN
+        y_column = TileKey.TILE_TOP if self.tiling_version == 1 else PandaTilesDataset.TILE_Y_COLUMN
         csv_columns = [
             PandaTilesDataset.SLIDE_ID_COLUMN,
             PandaTilesDataset.TILE_ID_COLUMN,

--- a/hi-ml-cpath/testhisto/testhisto/mocks/tiles_generator.py
+++ b/hi-ml-cpath/testhisto/testhisto/mocks/tiles_generator.py
@@ -10,18 +10,22 @@ import torch
 from torchvision.utils import save_image
 
 from health_cpath.datasets.panda_tiles_dataset import PandaTilesDataset
+from health_cpath.utils.naming import TileKey
 from testhisto.mocks.base_data_generator import MockHistoDataGenerator, MockHistoDataType, PANDA_N_CLASSES
 
 
 class MockPandaTilesGenerator(MockHistoDataGenerator):
     """Generator class to create mock tiles dataset on the fly. The tiles are positioned randomly in a wsi grid."""
 
-    def __init__(self, img_size: int = 224, **kwargs: Any) -> None:
+    def __init__(self, img_size: int = 224, version: int = 0, **kwargs: Any) -> None:
         """
         :param img_size: The whole slide image resolution, defaults to 224.
+        :param version: The version of the tiles dataset, defaults to 0. This is used to support both the old and new
+        tiling scheme where coordinates are stored as tile_x and tile_y in v0 and as tile_left and tile_top in v1.
         :param kwargs: Same params passed to MockHistoDataGenerator.
         """
         self.img_size = img_size
+        self.version = version
         super().__init__(**kwargs)
 
     def validate(self) -> None:
@@ -32,16 +36,19 @@ class MockPandaTilesGenerator(MockHistoDataGenerator):
             f"The image of size {self.img_size} can't contain more than {(self.img_size // self.tile_size)**2} tiles."
             f"Choose a number of tiles 0 < n_tiles <= {(self.img_size // self.tile_size)**2} "
         )
+        assert self.version in [0, 1], f"Version should be 0 or 1, got {self.version}"
 
     def create_mock_metadata_dataframe(self) -> pd.DataFrame:
         """Create a mock dataframe with random metadata."""
+        x_column = TileKey.TILE_LEFT if self.version == 1 else PandaTilesDataset.TILE_X_COLUMN
+        y_column = TileKey.TILE_TOP if self.version == 1 else PandaTilesDataset.TILE_Y_COLUMN
         csv_columns = [
             PandaTilesDataset.SLIDE_ID_COLUMN,
             PandaTilesDataset.TILE_ID_COLUMN,
             PandaTilesDataset.IMAGE_COLUMN,
             self.MASK_COLUMN,
-            PandaTilesDataset.TILE_X_COLUMN,
-            PandaTilesDataset.TILE_Y_COLUMN,
+            x_column,
+            y_column,
             self.OCCUPANCY,
             self.DATA_PROVIDER,
             self.ISUP_GRADE,
@@ -81,8 +88,9 @@ class MockPandaTilesGenerator(MockHistoDataGenerator):
                     f"_{slide_id}/train_images/{tile_x}x_{tile_y}y.png"
                 )
                 mock_metadata[self.MASK_COLUMN].append(f"_{slide_id}/train_label_masks/{tile_x}x_{tile_y}y_mask.png")
-                mock_metadata[PandaTilesDataset.TILE_X_COLUMN].append(tile_x)
-                mock_metadata[PandaTilesDataset.TILE_Y_COLUMN].append(tile_y)
+                mock_metadata[x_column].append(tile_x)
+                mock_metadata[y_column].append(tile_y)
+
                 mock_metadata[self.OCCUPANCY].append(1.0)
                 mock_metadata[self.DATA_PROVIDER].append(data_provider)
                 mock_metadata[self.ISUP_GRADE].append(isup_grade)


### PR DESCRIPTION
Use df.assign to fix SettingWithCopyWarning  warning and make metadata validation optional to be able to read only subsets of dataset csv