### PR TITLE
ENH: Enable stain normalization for multiple images

### DIFF
--- a/hi-ml/src/health_ml/run_ml.py
+++ b/hi-ml/src/health_ml/run_ml.py
@@ -5,7 +5,7 @@
 import os
 import sys
 import logging
-import torch.multiprocessing
+import torch
 
 from pathlib import Path
 from typing import Dict, List, Optional

--- a/hi-ml/src/health_ml/utils/data_augmentations.py
+++ b/hi-ml/src/health_ml/utils/data_augmentations.py
@@ -131,7 +131,14 @@ class StainNormalization(object):
         return nimg
 
     def __call__(self, img: torch.Tensor) -> torch.Tensor:
-        return self.stain_normalize(img, self.reference_mean, self.reference_std)
+        # if the input is a bag of images, stain normalization needs to run on each image separately
+        if img.shape[0] > 1:
+            for i in range(img.shape[0]):
+                img_tile = img[i]
+                img[i] = self.stain_normalize(img_tile.unsqueeze(0), self.reference_mean, self.reference_std)
+            return img
+        else:
+            return self.stain_normalize(img, self.reference_mean, self.reference_std)
 
 
 class GaussianBlur(object):

--- a/hi-ml/testhiml/testhiml/test_data_augmentations.py
+++ b/hi-ml/testhiml/testhiml/test_data_augmentations.py
@@ -16,6 +16,7 @@ dummy_img = torch.Tensor(
        [0.8717, 0.9098]],
       [[0.1592, 0.7216],
        [0.8305, 0.1127]]]])
+dummy_bag = torch.stack([dummy_img.squeeze(0), dummy_img.squeeze(0)])
 
 
 def _test_data_augmentation(data_augmentation: Callable[[Tensor], Tensor],
@@ -59,8 +60,10 @@ def test_stain_normalization() -> None:
           [0.8706, 0.4863]],
          [[0.8235, 0.5294],
           [0.8275, 0.7725]]]])
+    expected_output_bag = torch.stack([expected_output_img.squeeze(0), expected_output_img.squeeze(0)])
 
     _test_data_augmentation(data_augmentation, dummy_img, expected_output_img, stochastic=False)
+    _test_data_augmentation(data_augmentation, dummy_bag, expected_output_bag, stochastic=False)
 
 
 def test_hed_jitter() -> None:

--- a/hi-ml/testhiml/testhiml/test_run_ml.py
+++ b/hi-ml/testhiml/testhiml/test_run_ml.py
@@ -246,7 +246,7 @@ def test_run(run_inference_only: bool, run_extra_val_epoch: bool, ml_runner_with
             mock_create_trainer.return_value = MagicMock(), MagicMock()
             ml_runner_with_container.run()
 
-            mocks["load_model_checkpoint"].called == run_extra_val_epoch
+            assert mocks["load_model_checkpoint"].called == run_extra_val_epoch
             assert ml_runner_with_container._has_setup_run
             assert ml_runner_with_container.checkpoint_handler.has_continued_training != run_inference_only
 

--- a/hi-ml/testhiml/testhiml/test_run_ml.py
+++ b/hi-ml/testhiml/testhiml/test_run_ml.py
@@ -246,7 +246,11 @@ def test_run(run_inference_only: bool, run_extra_val_epoch: bool, ml_runner_with
             mock_create_trainer.return_value = MagicMock(), MagicMock()
             ml_runner_with_container.run()
 
-            assert mocks["load_model_checkpoint"].called == run_extra_val_epoch
+            # Checkpoints will only be loaded explicitly when doing training. Checkpoint loading is guarded
+            # also by checking if the model has a custom test step, this is always True for the HelloWorld model used
+            # here.
+            assert ml_runner_with_container.container.has_custom_test_step()
+            assert mocks["load_model_checkpoint"].called != run_inference_only
             assert ml_runner_with_container._has_setup_run
             assert ml_runner_with_container.checkpoint_handler.has_continued_training != run_inference_only
 


### PR DESCRIPTION
Enable stain normalization to work with multiple images (e.g., when a bag of tiles is given as input).