### PR TITLE
BUG: Fix top bottom tiles selection mismatch.

### DIFF
--- a/hi-ml-cpath/src/health_cpath/utils/tiles_selection_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/tiles_selection_utils.py
@@ -180,30 +180,33 @@ class TilesSelector:
                 pred_prob_score = results[ResultsKey.CLASS_PROBS][:, pred_label][i].item()
                 tiles = batch[SlideKey.IMAGE][i]
                 attn_scores = results[ResultsKey.BAG_ATTN][i].squeeze(0)
-                self._update_label_slides(
-                    class_slides_heap=self.top_slides_heaps[gt_label],
-                    tiles=tiles,
-                    attn_scores=attn_scores,
-                    slide_node=SlideNode(
-                        slide_id=slide_ids[i],
-                        gt_prob_score=gt_prob_score,
-                        pred_prob_score=pred_prob_score,
-                        true_label=gt_label,
-                        pred_label=pred_label,
-                    ),
-                )
-                self._update_label_slides(
-                    class_slides_heap=self.bottom_slides_heaps[gt_label],
-                    tiles=tiles,
-                    attn_scores=attn_scores,
-                    slide_node=SlideNode(
-                        slide_id=slide_ids[i],
-                        gt_prob_score=-gt_prob_score,  # negative score for bottom slides to reverse order in max heap
-                        pred_prob_score=pred_prob_score,
-                        true_label=gt_label,
-                        pred_label=pred_label,
-                    ),
-                )
+                if pred_label == gt_label:
+                    self._update_label_slides(
+                        class_slides_heap=self.top_slides_heaps[gt_label],
+                        tiles=tiles,
+                        attn_scores=attn_scores,
+                        slide_node=SlideNode(
+                            slide_id=slide_ids[i],
+                            gt_prob_score=gt_prob_score,
+                            pred_prob_score=pred_prob_score,
+                            true_label=gt_label,
+                            pred_label=pred_label,
+                        ),
+                    )
+                elif pred_label != gt_label:
+                    self._update_label_slides(
+                        class_slides_heap=self.bottom_slides_heaps[gt_label],
+                        tiles=tiles,
+                        attn_scores=attn_scores,
+                        slide_node=SlideNode(
+                            slide_id=slide_ids[i],
+                            # negative score for bottom slides to reverse order in max heap
+                            gt_prob_score=-gt_prob_score,
+                            pred_prob_score=pred_prob_score,
+                            true_label=gt_label,
+                            pred_label=pred_label,
+                        ),
+                    )
 
     def _shallow_copy_slides_heaps(self, slides_heaps: SlideDict) -> SlideDict:
         """Returns a shallow copy of slides heaps to be synchronised across devices.

--- a/hi-ml-cpath/src/health_cpath/utils/tiles_selection_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/tiles_selection_utils.py
@@ -110,22 +110,9 @@ class TilesSelector:
         self.num_tiles = num_tiles
         self.top_slides_heaps: SlideDict = self._initialise_slide_heaps()
         self.bottom_slides_heaps: SlideDict = self._initialise_slide_heaps()
-        self.report_cases_slide_ids = self.init_report_cases()
 
     def _initialise_slide_heaps(self) -> SlideDict:
         return {class_id: [] for class_id in range(self.n_classes)}
-
-    def init_report_cases(self) -> Dict[str, List[str]]:
-        """ Initializes the report cases dictionary to store slide_ids per case.
-        Possible cases are set such as class 0 is considered to be the negative class.
-
-        :return: A dictionary that maps TN/FP TP_{i}/FN_{i}, i={1,..., self.n_classes+1} cases to an empty list to be
-            filled with corresponding slide ids.
-        """
-        report_cases: Dict[str, List[str]] = {"TN": [], "FP": []}
-        report_cases.update({f"TP_{class_id}": [] for class_id in range(1, self.n_classes)})
-        report_cases.update({f"FN_{class_id}": [] for class_id in range(1, self.n_classes)})
-        return report_cases
 
     def _clear_cached_slides_heaps(self) -> None:
         self.top_slides_heaps = self._initialise_slide_heaps()

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_tiles_selection_utils.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_tiles_selection_utils.py
@@ -42,12 +42,13 @@ def _create_mock_results(n_samples: int, n_tiles: int = 3, n_classes: int = 2, d
     :return: A dictioanry containing randomly generated mock results.
     """
     diff_n_tiles = [n_tiles + i for i in range(n_samples)]
+    probs = torch.rand((n_samples, n_classes), device=device)
     mock_results = {
         ResultsKey.SLIDE_ID: np.array([f"slide_{i}" for i in range(n_samples)]),
         ResultsKey.TRUE_LABEL: torch.randint(2, size=(n_samples,), device=device),
-        ResultsKey.PRED_LABEL: torch.randint(2, size=(n_samples,), device=device),
+        ResultsKey.PRED_LABEL: torch.argmax(probs, dim=1),
         ResultsKey.BAG_ATTN: [torch.rand(size=(1, diff_n_tiles[i]), device=device) for i in range(n_samples)],
-        ResultsKey.CLASS_PROBS: torch.rand((n_samples, n_classes), device=device),
+        ResultsKey.CLASS_PROBS: probs / probs.sum(dim=1, keepdim=True),
     }
     return mock_results
 

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_tiles_selection_utils.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_tiles_selection_utils.py
@@ -183,12 +183,12 @@ def test_aggregate_shallow_slide_nodes(
 @pytest.mark.gpu
 def test_aggregate_shallow_slide_nodes_distributed() -> None:
     """These tests need to be called sequentially to prevent them to be run in parallel."""
-    # test with n_classes = 2
-    run_distributed(test_aggregate_shallow_slide_nodes, [2], world_size=1)
-    run_distributed(test_aggregate_shallow_slide_nodes, [2], world_size=2)
-    # test with n_classes = 3
-    run_distributed(test_aggregate_shallow_slide_nodes, [3], world_size=1)
-    run_distributed(test_aggregate_shallow_slide_nodes, [3], world_size=2)
+    # test with n_classes = 2, n_slides = 2
+    run_distributed(test_aggregate_shallow_slide_nodes, [2, 2], world_size=1)
+    run_distributed(test_aggregate_shallow_slide_nodes, [2, 2], world_size=2)
+    # test with n_classes = 3, n_slides = 2
+    run_distributed(test_aggregate_shallow_slide_nodes, [3, 2], world_size=1)
+    run_distributed(test_aggregate_shallow_slide_nodes, [3, 2], world_size=2)
 
 
 def assert_equal_top_bottom_attention_tiles(
@@ -304,12 +304,12 @@ def test_select_k_top_bottom_tiles_on_the_fly(
 @pytest.mark.gpu
 def test_select_k_top_bottom_tiles_on_the_fly_distributed() -> None:
     """These tests need to be called sequentially to prevent them to be run in parallel"""
-    # test with n_classes = 2
-    run_distributed(test_select_k_top_bottom_tiles_on_the_fly, [2], world_size=1)
-    run_distributed(test_select_k_top_bottom_tiles_on_the_fly, [2], world_size=2)
-    # test with n_classes = 3
-    run_distributed(test_select_k_top_bottom_tiles_on_the_fly, [3], world_size=1)
-    run_distributed(test_select_k_top_bottom_tiles_on_the_fly, [3], world_size=2)
+    # test with n_classes = 2, n_slides = 2
+    run_distributed(test_select_k_top_bottom_tiles_on_the_fly, [2, 2], world_size=1)
+    run_distributed(test_select_k_top_bottom_tiles_on_the_fly, [2, 2], world_size=2)
+    # test with n_classes = 3, n_slides = 2
+    run_distributed(test_select_k_top_bottom_tiles_on_the_fly, [3, 2], world_size=1)
+    run_distributed(test_select_k_top_bottom_tiles_on_the_fly, [3, 2], world_size=2)
 
 
 def test_disable_top_bottom_tiles_selector() -> None:

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_tiles_selection_utils.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_tiles_selection_utils.py
@@ -57,7 +57,7 @@ def _batch_data(data: Dict, batch_idx: int, batch_size: int) -> Dict:
     """Helper function to generate smaller batches from a dictionary."""
     batch = {}
     for k in data:
-        batch[k] = data[k][batch_idx * batch_size : (batch_idx + 1) * batch_size]
+        batch[k] = data[k][batch_idx * batch_size: (batch_idx + 1) * batch_size]
     return batch
 
 

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_tiles_selection_utils.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_tiles_selection_utils.py
@@ -181,6 +181,7 @@ def test_aggregate_shallow_slide_nodes(n_classes: int, rank: int = 0, world_size
             expected_bottom_slides_ids = _get_expected_slides_by_probability(results, num_top_slides, label, top=False)
             assert expected_bottom_slides_ids == selected_bottom_slides_ids
 
+            # Make sure that the top and bottom slides are disjoint.
             assert not set(selected_top_slides_ids).intersection(set(selected_bottom_slides_ids))
 
 


### PR DESCRIPTION
For small validation sets and poor performance models, we sometimes end up with some slides falsely belonging to TP/FN cases. 
We need to make sure thay top_heaps contain only true cases and bottom ones, only false cases.
Check predicted vs true label before pushing into slides_heaps to make sure we only push true predictions in top_slides_heaps and false ones in bottom_slides_heaps