### PR TITLE
ENH: Make crossval html report generic to all hyperdrive runs

### DIFF
--- a/hi-ml-cpath/src/health_cpath/scripts/generate_crossval_report.py
+++ b/hi-ml-cpath/src/health_cpath/scripts/generate_crossval_report.py
@@ -65,12 +65,12 @@ def generate_html_report(parent_run_id: str, output_dir: Path,
     # Get metrics list with class names
     num_classes, class_names = collect_class_info(metrics_df=metrics_df)
 
-    base_metrics_list: List[str]
+    base_metrics_list: List[str] = [MetricsKey.ACC, MetricsKey.AUROC, MetricsKey.AVERAGE_PRECISION,
+                                    MetricsKey.COHENKAPPA]
     if num_classes > 1:
-        base_metrics_list = [MetricsKey.ACC, MetricsKey.AUROC]
+        base_metrics_list += [MetricsKey.ACC_MACRO, MetricsKey.ACC_WEIGHTED]
     else:
-        base_metrics_list = [MetricsKey.ACC, MetricsKey.AUROC, MetricsKey.PRECISION, MetricsKey.RECALL, MetricsKey.F1,
-                             MetricsKey.AVERAGE_PRECISION, MetricsKey.COHENKAPPA, MetricsKey.SPECIFICITY]
+        base_metrics_list += [MetricsKey.F1, MetricsKey.PRECISION, MetricsKey.RECALL, MetricsKey.SPECIFICITY]
 
     base_metrics_list += class_names
 
@@ -254,7 +254,7 @@ if __name__ == "__main__":
                                                                  "even if they already exist locally.")
     parser.add_argument("--hyper_arg_name", default="crossval_index",
                         help="Name of the Hyperdrive argument used for indexing the child runs.")
-    parser.add_argument("--primary_metric", default="auroc", help="Name of the reference metric to optimise.")
+    parser.add_argument("--primary_metric", default=MetricsKey.AUROC, help="Name of the reference metric to optimise.")
     args = parser.parse_args()
 
     if args.output_dir is None:

--- a/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
@@ -201,7 +201,7 @@ def _plot_hyperdrive_roc_and_pr_curves(hyperdrive_dfs: Dict[int, pd.DataFrame], 
 
 def plot_hyperdrive_roc_and_pr_curves(hyperdrive_dfs: Dict[int, pd.DataFrame],
                                       scores_column: str = ResultsKey.PROB) -> Figure:
-    """Plot ROC and precision-recall curves for multiple hyperdrive cgild runs.
+    """Plot ROC and precision-recall curves for multiple hyperdrive child runs.
 
     This will create a new figure with two subplots (left: ROC, right: PR).
 

--- a/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
@@ -280,6 +280,7 @@ def plot_confusion_matrices(hyperdrive_dfs: Dict[int, pd.DataFrame], class_names
     """
     hyperdrive_count = len(hyperdrive_dfs)
     fig, axs = plt.subplots(1, hyperdrive_count, figsize=(hyperdrive_count * 6, 5))
+    ax_index = 0
     for k, tiles_df in hyperdrive_dfs.items():
         slides_groupby = tiles_df.groupby(ResultsKey.SLIDE_ID)
         tile_labels_true = slides_groupby[ResultsKey.TRUE_LABEL]
@@ -296,9 +297,10 @@ def plot_confusion_matrices(hyperdrive_dfs: Dict[int, pd.DataFrame], class_names
         labels_pred = tile_labels_pred.first()
 
         cf_matrix_n = confusion_matrix(y_true=labels_true, y_pred=labels_pred, normalize='true')
-        sns.heatmap(cf_matrix_n, annot=True, cmap='Blues', fmt=".2%", ax=axs[k],
+        sns.heatmap(cf_matrix_n, annot=True, cmap='Blues', fmt=".2%", ax=axs[ax_index],
                     xticklabels=class_names, yticklabels=class_names)
-        axs[k].set_xlabel('Predicted')
-        axs[k].set_ylabel('True')
-        axs[k].set_title(f'Child {k}')
+        axs[ax_index].set_xlabel('Predicted')
+        axs[ax_index].set_ylabel('True')
+        axs[ax_index].set_title(f'Child {k}')
+        ax_index += 1
     return fig

--- a/hi-ml-cpath/src/health_cpath/utils/report_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/report_utils.py
@@ -133,7 +133,7 @@ def get_hyperdrive_metrics_table(metrics_df: pd.DataFrame, metrics_list: Sequenc
     :return: A dataframe with the values of the selected metrics formatted as strings, including a
         header and a summary column.
     """
-    header = ["Metric"] + [f"Split {k}" for k in metrics_df.columns] + ["Mean ± Std"]
+    header = ["Metric"] + [f"Child {k}" for k in metrics_df.columns] + ["Mean ± Std"]
     metrics_rows = []
     for metric in metrics_list:
         values: pd.Series = metrics_df.loc[metric]


### PR DESCRIPTION
* Add commandline arguments to parametrise child runs arg identifier and primary metric to get best_epoch.
* Rename all crossval functions to hyperdrive ones to make it generic