### PR TITLE
ENH: Refactor extra validation epoch logic

### DIFF
--- a/hi-ml-cpath/src/health_cpath/models/deepmil.py
+++ b/hi-ml-cpath/src/health_cpath/models/deepmil.py
@@ -91,8 +91,8 @@ class BaseDeepMILModule(LightningModule):
         self.pretrained_classifier = pretrained_classifier
 
         # This flag can be switched on before invoking trainer.validate() to enable saving additional time/memory
-        # consuming validation outputs
-        self.run_extra_val_epoch = False
+        # consuming validation outputs via calling self.on_extra_validation_epoch_start()
+        self._run_extra_val_epoch = False
         self.tune_classifier = tune_classifier
 
         # Model components
@@ -333,7 +333,7 @@ class BaseDeepMILModule(LightningModule):
                         })
         self.update_results_with_data_specific_info(batch=batch, results=results)
         if (
-            (stage == ModelKey.TEST or (stage == ModelKey.VAL and self.run_extra_val_epoch))
+            (stage == ModelKey.TEST or (stage == ModelKey.VAL and self._run_extra_val_epoch))
             and self.outputs_handler
             and self.outputs_handler.tiles_selector
         ):
@@ -366,16 +366,12 @@ class BaseDeepMILModule(LightningModule):
     def validation_epoch_end(self, epoch_results: EpochResultsType) -> None:  # type: ignore
         self.log_metrics(ModelKey.VAL)
         if self.outputs_handler:
-            if self.run_extra_val_epoch:
-                self.outputs_handler.val_plots_handler.plot_options = (
-                    self.outputs_handler.test_plots_handler.plot_options
-                )
             self.outputs_handler.save_validation_outputs(
                 epoch_results=epoch_results,
                 metrics_dict=self.get_metrics_dict(ModelKey.VAL),  # type: ignore
                 epoch=self.current_epoch,
                 is_global_rank_zero=self.global_rank == 0,
-                run_extra_val_epoch=self.run_extra_val_epoch
+                run_extra_val_epoch=self._run_extra_val_epoch
             )
 
             # Reset the top and bottom slides heaps
@@ -389,6 +385,13 @@ class BaseDeepMILModule(LightningModule):
                 epoch_results=epoch_results,
                 is_global_rank_zero=self.global_rank == 0
             )
+
+    def on_extra_validation_epoch_start(self) -> None:
+        """Hook to be called at the beginning of an extra validation epoch to set validation plots options to the same
+        as the test plots options."""
+        self._run_extra_val_epoch = True
+        if self.outputs_handler:
+            self.outputs_handler.val_plots_handler.plot_options = self.outputs_handler.test_plots_handler.plot_options
 
 
 class TilesDeepMILModule(BaseDeepMILModule):

--- a/hi-ml-cpath/src/health_cpath/models/deepmil.py
+++ b/hi-ml-cpath/src/health_cpath/models/deepmil.py
@@ -91,7 +91,7 @@ class BaseDeepMILModule(LightningModule):
         self.pretrained_classifier = pretrained_classifier
 
         # This flag can be switched on before invoking trainer.validate() to enable saving additional time/memory
-        # consuming validation outputs via calling self.on_extra_validation_epoch_start()
+        # consuming validation outputs via calling self.on_run_extra_validation_epoch()
         self._run_extra_val_epoch = False
         self.tune_classifier = tune_classifier
 
@@ -386,7 +386,7 @@ class BaseDeepMILModule(LightningModule):
                 is_global_rank_zero=self.global_rank == 0
             )
 
-    def on_extra_validation_epoch_start(self) -> None:
+    def on_run_extra_validation_epoch(self) -> None:
         """Hook to be called at the beginning of an extra validation epoch to set validation plots options to the same
         as the test plots options."""
         self._run_extra_val_epoch = True

--- a/hi-ml-cpath/testhisto/testhisto/models/test_deepmil.py
+++ b/hi-ml-cpath/testhisto/testhisto/models/test_deepmil.py
@@ -700,3 +700,21 @@ def test_checkpoint_name(container_type: Type[BaseMILTiles], primary_val_metric:
 
     metric_optim = "max" if maximise_primary_metric else "min"
     assert container.best_checkpoint_filename == f"checkpoint_{metric_optim}_val_{primary_val_metric.value}"
+
+
+def test_on_run_extra_val_epoch(mock_panda_tiles_root_dir: Path) -> None:
+    container = MockDeepSMILETilesPanda(tmp_path=mock_panda_tiles_root_dir)
+    container.setup()
+    container.data_module = MagicMock()
+    container.create_lightning_module_and_store()
+    assert not container.model._run_extra_val_epoch
+    assert (
+        container.model.outputs_handler.test_plots_handler.plot_options  # type: ignore
+        != container.model.outputs_handler.val_plots_handler.plot_options  # type: ignore
+    )
+    container.on_run_extra_validation_epoch()
+    assert container.model._run_extra_val_epoch
+    assert (
+        container.model.outputs_handler.test_plots_handler.plot_options  # type: ignore
+        == container.model.outputs_handler.val_plots_handler.plot_options  # type: ignore
+    )

--- a/hi-ml/src/health_ml/configs/hello_world.py
+++ b/hi-ml/src/health_ml/configs/hello_world.py
@@ -232,7 +232,7 @@ class HelloRegression(LightningModule):
         Path("test_mae.txt").write_text(str(self.test_mae.compute().item()))
         self.log("test_mse", average_mse, on_epoch=True, on_step=False)
 
-    def on_extra_validation_epoch_start(self) -> None:
+    def on_run_extra_validation_epoch(self) -> None:
         self._run_extra_val_epoch = True
 
 

--- a/hi-ml/src/health_ml/configs/hello_world.py
+++ b/hi-ml/src/health_ml/configs/hello_world.py
@@ -122,7 +122,7 @@ class HelloRegression(LightningModule):
         self.model = torch.nn.Linear(in_features=1, out_features=1, bias=True)  # type: ignore
         self.test_mse: List[torch.Tensor] = []
         self.test_mae = MeanAbsoluteError()
-        self.run_extra_val_epoch = False
+        self._run_extra_val_epoch = False
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore
         """
@@ -231,6 +231,9 @@ class HelloRegression(LightningModule):
         Path("test_mse.txt").write_text(str(average_mse.item()))
         Path("test_mae.txt").write_text(str(self.test_mae.compute().item()))
         self.log("test_mse", average_mse, on_epoch=True, on_step=False)
+
+    def on_extra_validation_epoch_start(self) -> None:
+        self._run_extra_val_epoch = True
 
 
 class HelloWorld(LightningContainer):

--- a/hi-ml/src/health_ml/lightning_container.py
+++ b/hi-ml/src/health_ml/lightning_container.py
@@ -230,7 +230,7 @@ class LightningContainer(WorkflowParams,
         return {}
 
     def on_run_extra_validation_epoch(self) -> None:
-        if hasattr(self.model, "on_run_extra_validation_epochv"):
+        if hasattr(self.model, "on_run_extra_validation_epoch"):
             assert self._model, "Model is not initialized."
             self.model.on_run_extra_validation_epoch()  # type: ignore
         else:

--- a/hi-ml/src/health_ml/lightning_container.py
+++ b/hi-ml/src/health_ml/lightning_container.py
@@ -229,12 +229,12 @@ class LightningContainer(WorkflowParams,
         """Returns a dictionary of tags that should be added to the AzureML run."""
         return {}
 
-    def on_extra_validation_epoch_start(self) -> None:
-        if hasattr(self.model, "on_extra_validation_epoch_start"):
+    def on_run_extra_validation_epoch(self) -> None:
+        if hasattr(self.model, "on_run_extra_validation_epochv"):
             assert self._model, "Model is not initialized."
-            self.model.on_extra_validation_epoch_start()  # type: ignore
+            self.model.on_run_extra_validation_epoch()  # type: ignore
         else:
-            logging.info("Hook `on_extra_validation_epoch_start` is not implemented by lightning module."
+            logging.info("Hook `on_run_extra_validation_epoch` is not implemented by lightning module."
                          "The extra validation epoch won't produce any extra outputs.")
 
 

--- a/hi-ml/src/health_ml/lightning_container.py
+++ b/hi-ml/src/health_ml/lightning_container.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from pathlib import Path
 
 import param
+import logging
 from azureml.core import ScriptRunConfig
 from azureml.train.hyperdrive import HyperDriveConfig
 from pytorch_lightning import Callback, LightningDataModule, LightningModule
@@ -229,10 +230,12 @@ class LightningContainer(WorkflowParams,
         return {}
 
     def on_extra_validation_epoch_start(self) -> None:
-        assert hasattr(self.model, "on_extra_validation_epoch_start"), "Hook `on_extra_validation_epoch_start` is not "
-        "implemented by lightning module. This is required for running an additional validation epoch to save plots."
-        assert self._model, "Model is not initialized."
-        self._model.on_extra_validation_epoch_start()
+        if hasattr(self.model, "on_extra_validation_epoch_start"):
+            assert self._model, "Model is not initialized."
+            self._model.on_extra_validation_epoch_start()
+        else:
+            logging.info("Hook `on_extra_validation_epoch_start` is not implemented by lightning module."
+                         "The extra validation epoch won't produce any extra outputs.")
 
 
 class LightningModuleWithOptimizer(LightningModule):

--- a/hi-ml/src/health_ml/lightning_container.py
+++ b/hi-ml/src/health_ml/lightning_container.py
@@ -228,6 +228,12 @@ class LightningContainer(WorkflowParams,
         """Returns a dictionary of tags that should be added to the AzureML run."""
         return {}
 
+    def on_extra_validation_epoch_start(self) -> None:
+        assert hasattr(self.model, "on_extra_validation_epoch_start"), "Hook `on_extra_validation_epoch_start` is not "
+        "implemented by lightning module. This is required for running an additional validation epoch to save plots."
+        assert self._model, "Model is not initialized."
+        self._model.on_extra_validation_epoch_start()
+
 
 class LightningModuleWithOptimizer(LightningModule):
     """

--- a/hi-ml/src/health_ml/lightning_container.py
+++ b/hi-ml/src/health_ml/lightning_container.py
@@ -234,8 +234,8 @@ class LightningContainer(WorkflowParams,
             assert self._model, "Model is not initialized."
             self.model.on_run_extra_validation_epoch()  # type: ignore
         else:
-            logging.info("Hook `on_run_extra_validation_epoch` is not implemented by lightning module."
-                         "The extra validation epoch won't produce any extra outputs.")
+            logging.warning("Hook `on_run_extra_validation_epoch` is not implemented by lightning module."
+                            "The extra validation epoch won't produce any extra outputs.")
 
 
 class LightningModuleWithOptimizer(LightningModule):

--- a/hi-ml/src/health_ml/lightning_container.py
+++ b/hi-ml/src/health_ml/lightning_container.py
@@ -232,7 +232,7 @@ class LightningContainer(WorkflowParams,
     def on_extra_validation_epoch_start(self) -> None:
         if hasattr(self.model, "on_extra_validation_epoch_start"):
             assert self._model, "Model is not initialized."
-            self._model.on_extra_validation_epoch_start()
+            self.model.on_extra_validation_epoch_start()  # type: ignore
         else:
             logging.info("Hook `on_extra_validation_epoch_start` is not implemented by lightning module."
                          "The extra validation epoch won't produce any extra outputs.")

--- a/hi-ml/src/health_ml/run_ml.py
+++ b/hi-ml/src/health_ml/run_ml.py
@@ -277,9 +277,7 @@ class MLRunner:
         """
         Run validation on the validation set for all models to save time/memory consuming outputs.
         """
-        assert hasattr(self.container.model, "run_extra_val_epoch"), "Model does not have run_extra_val_epoch flag."
-        "This is required for running an additional validation epoch to save plots."
-        self.container.model.run_extra_val_epoch = True  # type: ignore
+        self.container.on_extra_validation_epoch_start()
         with change_working_directory(self.container.outputs_folder):
             assert self.trainer, "Trainer should be initialized before validation. Call self.init_training() first."
             self.trainer.validate(self.container.model, datamodule=self.data_module)

--- a/hi-ml/src/health_ml/run_ml.py
+++ b/hi-ml/src/health_ml/run_ml.py
@@ -277,7 +277,7 @@ class MLRunner:
         """
         Run validation on the validation set for all models to save time/memory consuming outputs.
         """
-        self.container.on_extra_validation_epoch_start()
+        self.container.on_run_extra_validation_epoch()
         with change_working_directory(self.container.outputs_folder):
             assert self.trainer, "Trainer should be initialized before validation. Call self.init_training() first."
             self.trainer.validate(self.container.model, datamodule=self.data_module)

--- a/hi-ml/testhiml/testhiml/test_run_ml.py
+++ b/hi-ml/testhiml/testhiml/test_run_ml.py
@@ -163,7 +163,6 @@ def test_run_validation(run_extra_val_epoch: bool) -> None:
     container = HelloWorld()
     container.create_lightning_module_and_store()
     container.run_extra_val_epoch = run_extra_val_epoch
-    container.model._run_extra_val_epoch = run_extra_val_epoch  # type: ignore
     runner = MLRunner(experiment_config=experiment_config, container=container)
 
     with patch.object(container, "get_data_module"):
@@ -183,8 +182,9 @@ def test_run_validation(run_extra_val_epoch: bool) -> None:
                 if run_extra_val_epoch:
                     runner.run_validation()
 
-                assert mock_trainer.validate.called == run_extra_val_epoch
                 assert mock_on_extra_validation_epoch_start.called == run_extra_val_epoch
+                assert hasattr(container.model, "on_extra_validation_epoch_start")
+                assert mock_trainer.validate.called == run_extra_val_epoch
 
 
 def test_run_inference(ml_runner_with_container: MLRunner, tmp_path: Path) -> None:

--- a/hi-ml/testhiml/testhiml/test_run_ml.py
+++ b/hi-ml/testhiml/testhiml/test_run_ml.py
@@ -166,7 +166,7 @@ def test_run_validation(run_extra_val_epoch: bool) -> None:
     runner = MLRunner(experiment_config=experiment_config, container=container)
 
     with patch.object(container, "get_data_module"):
-        with patch.object(container, "on_extra_validation_epoch_start") as mock_on_extra_validation_epoch_start:
+        with patch.object(container, "on_run_extra_validation_epoch") as mock_on_run_extra_validation_epoch:
             with patch("health_ml.run_ml.create_lightning_trainer") as mock_create_trainer:
                 runner.setup()
                 mock_trainer = MagicMock()
@@ -182,8 +182,8 @@ def test_run_validation(run_extra_val_epoch: bool) -> None:
                 if run_extra_val_epoch:
                     runner.run_validation()
 
-                assert mock_on_extra_validation_epoch_start.called == run_extra_val_epoch
-                assert hasattr(container.model, "on_extra_validation_epoch_start")
+                assert mock_on_run_extra_validation_epoch.called == run_extra_val_epoch
+                assert hasattr(container.model, "on_run_extra_validation_epoch")
                 assert mock_trainer.validate.called == run_extra_val_epoch
 
 


### PR DESCRIPTION
Avoid accessing sensitive attributes from the runner
Add on_extra_val_epoch_start hook to avoid confusion