### PR TITLE
MNT: Fix YAML syntax for Amulet jobs

### DIFF
--- a/docs/source/amulet/config.yml
+++ b/docs/source/amulet/config.yml
@@ -1,3 +1,4 @@
+---
 environment:
   image: azureml/openmpi3.1.2-cuda10.2-cudnn7-ubuntu18.04:latest
   conda_yaml_file: $CONFIG_DIR/environment.yml
@@ -22,9 +23,9 @@ jobs:
 # either use a different name or respond with "replace existing job" if Amulet
 # complains that a job of that name already exists.
 - name: Amulet Example on CPU
- sku: C1
- command:
- - python docs/source/amulet/amulet_script.py
+  sku: C1
+  command:
+  - python docs/source/amulet/amulet_script.py
 - name: Amulet Example with 2 GPUs on same node, don't delete RANK
   sku: G2
   command:


### PR DESCRIPTION
This fixes the errors reported by http://www.yamllint.com/ and [pre-commit](https://results.pre-commit.ci/run/github/382004101/1665055387.-41Vk8XXSNe2Py8apajfxg):

```
while parsing a block mapping
  in "docs/source/amulet/config.yml", line 1, column 1
did not find expected key
  in "docs/source/amulet/config.yml", line 25, column 2
```

