### PR TITLE
FIX: Fix test_get_dataset

### DIFF
--- a/hi-ml-azure/testazure/testazure/test_datasets.py
+++ b/hi-ml-azure/testazure/testazure/test_datasets.py
@@ -164,7 +164,7 @@ def test_get_dataset() -> None:
     Test if a dataset that does not yet exist can be created from a folder in blob storage
     """
     # A folder with a single tiny file
-    tiny_dataset = "himl-tiny_dataset"
+    tiny_dataset = "himl_tiny_dataset"
     workspace = DEFAULT_WORKSPACE.workspace
     # When creating a dataset, we need a non-empty name
     with pytest.raises(ValueError) as ex:


### PR DESCRIPTION
I accidentally created a v2 data asset with the same name as a v1 dataset in our test suite. The data asset cannot be removed or renamed, hence I am renaming the v1 dataset in the test to get it passing again 