### PR TITLE
BUG: Fix HTML report 

### DIFF
--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1758,7 +1758,7 @@ def aggregate_hyperdrive_metrics(
         assert run_id is not None, "Either run or run_id must be provided"
         workspace = get_workspace(aml_workspace=aml_workspace, workspace_config_path=workspace_config_path)
         run = get_aml_run_from_run_id(run_id, aml_workspace=workspace)
-#    assert isinstance(run, HyperDriveRun)
+    assert isinstance(run, HyperDriveRun)
     metrics: DefaultDict = defaultdict()
     for child_run in run.get_children():  # type: ignore
         child_run_metrics = child_run.get_metrics()

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1758,7 +1758,7 @@ def aggregate_hyperdrive_metrics(
         assert run_id is not None, "Either run or run_id must be provided"
         workspace = get_workspace(aml_workspace=aml_workspace, workspace_config_path=workspace_config_path)
         run = get_aml_run_from_run_id(run_id, aml_workspace=workspace)
-    assert isinstance(run, HyperDriveRun)
+#    assert isinstance(run, HyperDriveRun)
     metrics: DefaultDict = defaultdict()
     for child_run in run.get_children():  # type: ignore
         child_run_metrics = child_run.get_metrics()

--- a/hi-ml-cpath/src/health_cpath/scripts/generate_crossval_report.py
+++ b/hi-ml-cpath/src/health_cpath/scripts/generate_crossval_report.py
@@ -19,7 +19,7 @@ from health_cpath.utils.output_utils import (AML_LEGACY_TEST_OUTPUTS_CSV, AML_TE
 from health_cpath.utils.report_utils import (collect_hyperdrive_metrics, collect_hyperdrive_outputs,
                                              child_runs_have_val_and_test_outputs, get_best_epoch_metrics,
                                              get_best_epochs, get_hyperdrive_metrics_table, get_formatted_run_info,
-                                             collect_class_info, collect_epoch_info,
+                                             collect_class_info, get_max_epochs,
                                              download_hyperdrive_metrics_if_required)
 from health_cpath.utils.naming import MetricsKey, ModelKey
 
@@ -60,7 +60,7 @@ def generate_html_report(parent_run_id: str, output_dir: Path,
     # Get metrics dataframe from the downloaded json file
     metrics_df = collect_hyperdrive_metrics(metrics_json=metrics_json)
 
-    max_epochs_dict = collect_epoch_info(metrics_df)
+    max_epochs_dict = get_max_epochs(metrics_df)
     best_epochs = get_best_epochs(metrics_df=metrics_df, primary_metric=f'{ModelKey.VAL}/{primary_metric}',
                                   max_epochs_dict=max_epochs_dict, maximise=True)
 

--- a/hi-ml-cpath/src/health_cpath/scripts/generate_crossval_report.py
+++ b/hi-ml-cpath/src/health_cpath/scripts/generate_crossval_report.py
@@ -18,8 +18,8 @@ from health_cpath.utils.output_utils import (AML_LEGACY_TEST_OUTPUTS_CSV, AML_TE
                                              AML_VAL_OUTPUTS_CSV)
 from health_cpath.utils.report_utils import (collect_hyperdrive_metrics, collect_hyperdrive_outputs,
                                              child_runs_have_val_and_test_outputs, get_best_epoch_metrics,
-                                             get_best_epochs, get_hyperdrive_metrics_table, get_formatted_run_info,
-                                             collect_class_info, get_max_epochs,
+                                             get_best_epochs, get_child_runs_hyperparams, get_hyperdrive_metrics_table,
+                                             get_formatted_run_info, collect_class_info, get_max_epochs,
                                              download_hyperdrive_metrics_if_required)
 from health_cpath.utils.naming import MetricsKey, ModelKey
 
@@ -60,7 +60,8 @@ def generate_html_report(parent_run_id: str, output_dir: Path,
     # Get metrics dataframe from the downloaded json file
     metrics_df = collect_hyperdrive_metrics(metrics_json=metrics_json)
 
-    max_epochs_dict = get_max_epochs(metrics_df)
+    hyperparameters_children = get_child_runs_hyperparams(metrics_df)
+    max_epochs_dict = get_max_epochs(hyperparams_children=hyperparameters_children)
     best_epochs = get_best_epochs(metrics_df=metrics_df, primary_metric=f'{ModelKey.VAL}/{primary_metric}',
                                   max_epochs_dict=max_epochs_dict, maximise=True)
 
@@ -70,7 +71,7 @@ def generate_html_report(parent_run_id: str, output_dir: Path,
                            primary_metric=primary_metric)
 
     # Get metrics list with class names
-    num_classes, class_names = collect_class_info(metrics_df=metrics_df)
+    num_classes, class_names = collect_class_info(hyperparams_children=hyperparameters_children)
 
     base_metrics_list: List[str] = [MetricsKey.ACC, MetricsKey.AUROC, MetricsKey.AVERAGE_PRECISION,
                                     MetricsKey.COHENKAPPA]

--- a/hi-ml-cpath/src/health_cpath/scripts/generate_crossval_report.py
+++ b/hi-ml-cpath/src/health_cpath/scripts/generate_crossval_report.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import pandas as pd
-import matplotlib
-matplotlib.use('agg')
 from matplotlib import pyplot as plt
 
 from health_azure.utils import get_aml_run_from_run_id, get_workspace
@@ -179,7 +177,7 @@ def render_training_curves(report: HTMLReport, heading: str, level: int,
                                         ylabel=metric, best_epochs=best_epochs, ax=axs[i])
     add_training_curves_legend(fig, include_best_epoch=True)
     training_curves_fig_path = report_dir / "training_curves.png"
-    fig.savefig(str(training_curves_fig_path), bbox_inches='tight')
+    fig.savefig(training_curves_fig_path, bbox_inches='tight')
     report.add_images([training_curves_fig_path], base64_encode=True)
 
 
@@ -221,7 +219,7 @@ def render_roc_and_pr_curves(report: HTMLReport, heading: str, level: int, repor
     report.add_heading(heading, level=level)
     fig = plot_hyperdrive_roc_and_pr_curves(outputs_dfs, scores_column='prob_class1')
     roc_pr_curves_fig_path = report_dir / f"{prefix}roc_pr_curves.png"
-    fig.savefig(str(roc_pr_curves_fig_path), bbox_inches='tight')
+    fig.savefig(roc_pr_curves_fig_path, bbox_inches='tight')
     report.add_images([roc_pr_curves_fig_path], base64_encode=True)
 
 
@@ -241,7 +239,7 @@ def render_confusion_matrices(report: HTMLReport, heading: str, level: int, clas
     report.add_heading(heading, level=level)
     fig = plot_confusion_matrices(hyperdrive_dfs=outputs_dfs, class_names=class_names)
     confusion_matrices_fig_path = report_dir / f"{prefix}confusion_matrices.png"
-    fig.savefig(str(confusion_matrices_fig_path), bbox_inches='tight')
+    fig.savefig(confusion_matrices_fig_path, bbox_inches='tight')
     report.add_images([confusion_matrices_fig_path], base64_encode=True)
 
 

--- a/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
@@ -255,7 +255,7 @@ def add_training_curves_legend(fig: Figure, include_best_epoch: bool = False) ->
     # Add primary legend for main lines (hyperdrive runs)
     handles, labels = plt.gca().get_legend_handles_labels()
     by_label = dict(zip(labels, handles))
-    fig.legend(list(by_label.values()), list(by_label.keys()), **legend_kwargs, loc='lower center',
+    fig.legend(by_label.values(), by_label.keys(), **legend_kwargs, loc='lower center',
                bbox_to_anchor=(0.5, -0.06), ncol=len(by_label))
 
     # Add secondary legend for line styles

--- a/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
@@ -255,7 +255,7 @@ def add_training_curves_legend(fig: Figure, include_best_epoch: bool = False) ->
     # Add primary legend for main lines (hyperdrive runs)
     handles, labels = plt.gca().get_legend_handles_labels()
     by_label = dict(zip(labels, handles))
-    fig.legend(by_label.values(), by_label.keys(), **legend_kwargs, loc='lower center',
+    fig.legend(list(by_label.values()), list(by_label.keys()), **legend_kwargs, loc='lower center',
                bbox_to_anchor=(0.5, -0.06), ncol=len(by_label))
 
     # Add secondary legend for line styles

--- a/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/analysis_plot_utils.py
@@ -229,14 +229,17 @@ def plot_hyperdrive_training_curves(metrics_df: pd.DataFrame, train_metric: str,
     for k in sorted(metrics_df.columns):
         train_values = metrics_df.loc[train_metric, k]
         val_values = metrics_df.loc[val_metric, k]
-        line, = ax.plot(train_values, **TRAIN_STYLE, label=f"Child {k}")
-        color = line.get_color()
-        ax.plot(val_values, color=color, **VAL_STYLE)
+        if train_values is not None:
+            line, = ax.plot(train_values, **TRAIN_STYLE, label=f"Child {k}")
+            color = line.get_color()
+        if val_values is not None:
+            ax.plot(val_values, color=color, **VAL_STYLE)
         if best_epochs is not None:
             best_epoch = best_epochs[k]
-            ax.plot(best_epoch, train_values[best_epoch], color=color, zorder=1000, **BEST_TRAIN_MARKER_STYLE)
-            ax.plot(best_epoch, val_values[best_epoch], color=color, zorder=1000, **BEST_VAL_MARKER_STYLE)
-            ax.axvline(best_epoch, color=color, **BEST_EPOCH_LINE_STYLE)
+            if best_epoch is not None:
+                ax.plot(best_epoch, train_values[best_epoch], color=color, zorder=1000, **BEST_TRAIN_MARKER_STYLE)
+                ax.plot(best_epoch, val_values[best_epoch], color=color, zorder=1000, **BEST_VAL_MARKER_STYLE)
+                ax.axvline(best_epoch, color=color, **BEST_EPOCH_LINE_STYLE)
     ax.grid(color='0.9')
     ax.set_xlabel("Epoch")
     if ylabel:

--- a/hi-ml-cpath/src/health_cpath/utils/naming.py
+++ b/hi-ml-cpath/src/health_cpath/utils/naming.py
@@ -89,6 +89,7 @@ class AMLMetricsJsonKey(str, Enum):
     VALUE = 'value'
     N_CLASSES = 'n_classes'
     CLASS_NAMES = 'class_names'
+    MAX_EPOCHS = 'max_epochs'
 
 
 class PlotOption(Enum):

--- a/hi-ml-cpath/src/health_cpath/utils/report_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/report_utils.py
@@ -139,7 +139,10 @@ def get_hyperdrive_metrics_table(metrics_df: pd.DataFrame, metrics_list: Sequenc
         values: pd.Series = metrics_df.loc[metric]
         mean = values.mean()
         std = values.std()
-        row = [metric] + [f"{v:.3f}" for v in values] + [f"{mean:.3f} ± {std:.3f}"]
+        round_values: List[str] = [f"{v:.3f}" if v is not None else f"{v}" for v in values]
+        agg_values: List[str] = [f"{mean:.3f} ± {std:.3f}"]
+        print(agg_values)
+        row = [metric] + round_values + agg_values
         metrics_rows.append(row)
     table = pd.DataFrame(metrics_rows, columns=header).set_index(header[0])
     return table
@@ -165,7 +168,7 @@ def get_best_epochs(metrics_df: pd.DataFrame, primary_metric: str, max_epochs_di
         # If extra validation epoch was logged (N+1), return only the first N elements
         primary_metric_list = primary_metric_list[:-1] \
             if (len(primary_metric_list) == max_epochs_dict[i] + 1) else primary_metric_list
-        best_epochs[i] = np.argmax(primary_metric_list) if maximise else np.argmin(primary_metric_list)
+        best_epochs[i] = int(np.argmax(primary_metric_list) if maximise else np.argmin(primary_metric_list))
     return best_epochs
 
 

--- a/hi-ml-cpath/src/health_cpath/utils/report_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/report_utils.py
@@ -171,7 +171,7 @@ def get_best_epochs(metrics_df: pd.DataFrame, primary_metric: str, max_epochs_di
     :return: Dictionary mapping each hyperdrive child index to its best epoch.
     """
     best_epochs = {}
-    for i in range(len(metrics_df.columns)):
+    for i in metrics_df.columns:
         primary_metric_list = metrics_df[i][primary_metric]
         # If extra validation epoch was logged (N+1), return only the first N elements
         primary_metric_list = primary_metric_list[:-1] \
@@ -265,7 +265,7 @@ def collect_epoch_info(metrics_df: pd.DataFrame) -> Dict[int, int]:
     :return: Number of classes and list of class names
     """
     max_epochs_dict = {}
-    for i in range(len(metrics_df.columns)):
+    for i in metrics_df.columns:
         hyperparams = metrics_df[i][AMLMetricsJsonKey.HYPERPARAMS]
         hyperparams_name = hyperparams[AMLMetricsJsonKey.NAME]
         hyperparams_value = hyperparams[AMLMetricsJsonKey.VALUE]

--- a/hi-ml-cpath/src/health_cpath/utils/report_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/report_utils.py
@@ -173,10 +173,13 @@ def get_best_epochs(metrics_df: pd.DataFrame, primary_metric: str, max_epochs_di
     best_epochs = {}
     for i in metrics_df.columns:
         primary_metric_list = metrics_df[i][primary_metric]
-        # If extra validation epoch was logged (N+1), return only the first N elements
-        primary_metric_list = primary_metric_list[:-1] \
-            if (len(primary_metric_list) == max_epochs_dict[i] + 1) else primary_metric_list
-        best_epochs[i] = int(np.argmax(primary_metric_list) if maximise else np.argmin(primary_metric_list))
+        if primary_metric_list is not None:
+            # If extra validation epoch was logged (N+1), return only the first N elements
+            primary_metric_list = primary_metric_list[:-1] \
+                if (len(primary_metric_list) == max_epochs_dict[i] + 1) else primary_metric_list
+            best_epochs[i] = int(np.argmax(primary_metric_list) if maximise else np.argmin(primary_metric_list))
+        else:
+            best_epochs[i] = None           # type:ignore
     return best_epochs
 
 
@@ -197,7 +200,7 @@ def get_best_epoch_metrics(metrics_df: pd.DataFrame, metrics_list: Sequence[str]
         containing only scalar values.
     """
     best_metrics = [metrics_df.loc[metrics_list, k].apply(lambda values: values[epoch])
-                    for k, epoch in best_epochs.items()]
+                    if epoch is not None else metrics_df.loc[metrics_list, k] for k, epoch in best_epochs.items()]
     best_metrics_df = pd.DataFrame(best_metrics).T
     return best_metrics_df
 

--- a/hi-ml-cpath/src/health_cpath/utils/report_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/report_utils.py
@@ -259,7 +259,7 @@ def collect_class_info(metrics_df: pd.DataFrame) -> Tuple[int, List[str]]:
 
 def collect_epoch_info(metrics_df: pd.DataFrame) -> Dict[int, int]:
     """
-    Get the maximum number of epochs from metrics dataframe
+    Get the maximum number of epochs for each round from metrics dataframe
     :param metrics_df: Metrics dataframe, as returned by :py:func:`collect_hyperdrive_metrics()` and
         :py:func:`~health_azure.aggregate_hyperdrive_metrics()`.
     :return: Number of classes and list of class names

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_report_utils.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_report_utils.py
@@ -14,7 +14,7 @@ from health_cpath.utils.output_utils import (AML_LEGACY_TEST_OUTPUTS_CSV, AML_OU
 from health_cpath.utils.report_utils import (collect_hyperdrive_metrics, collect_hyperdrive_outputs,
                                              child_runs_have_val_and_test_outputs, get_best_epoch_metrics,
                                              get_best_epochs, get_hyperdrive_metrics_table,
-                                             run_has_val_and_test_outputs)
+                                             run_has_val_and_test_outputs, download_hyperdrive_metrics_if_required)
 
 
 def test_run_has_val_and_test_outputs() -> None:
@@ -195,13 +195,15 @@ def best_epoch_metrics(metrics_df: pd.DataFrame, best_epochs: Dict[int, int]) ->
 def test_collect_hyperdrive_metrics(metrics_df: pd.DataFrame, tmp_path: Path, overwrite: bool) -> None:
     with patch('health_cpath.utils.report_utils.aggregate_hyperdrive_metrics',
                return_value=metrics_df) as mock_aggregate:
-        returned_df = collect_hyperdrive_metrics(parent_run_id="", download_dir=tmp_path,
-                                                 aml_workspace=None, overwrite=overwrite)
+        returned_json = download_hyperdrive_metrics_if_required(parent_run_id="", download_dir=tmp_path,
+                                                                aml_workspace=None, overwrite=overwrite)
+        returned_df = collect_hyperdrive_metrics(metrics_json=returned_json)
         mock_aggregate.assert_called_once()
         mock_aggregate.reset_mock()
 
-        new_returned_df = collect_hyperdrive_metrics(parent_run_id="", download_dir=tmp_path,
-                                                     aml_workspace=None, overwrite=overwrite)
+        new_returned_json = download_hyperdrive_metrics_if_required(parent_run_id="", download_dir=tmp_path,
+                                                                    aml_workspace=None, overwrite=overwrite)
+        new_returned_df = collect_hyperdrive_metrics(metrics_json=new_returned_json)
         if overwrite:
             mock_aggregate.assert_called_once()
         else:

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_report_utils.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_report_utils.py
@@ -258,4 +258,4 @@ def test_get_hyperdrive_metrics_table(
 
     original_values = df.loc[metrics_list].values
     table_values = metrics_table.iloc[:, :-1].applymap(float).values
-    assert (table_values == original_values).all()
+    assert (table_values[~pd.isnull(table_values)] == original_values[~pd.isnull(original_values)]).all()

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_report_utils.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_report_utils.py
@@ -182,7 +182,8 @@ def metrics_df() -> pd.DataFrame:
 
 @pytest.fixture
 def best_epochs(metrics_df: pd.DataFrame) -> Dict[int, int]:
-    return get_best_epochs(metrics_df, 'val/accuracy', maximise=True)
+    return get_best_epochs(metrics_df=metrics_df, primary_metric='val/accuracy',
+                           max_epochs_dict={0: 3, 1: 3, 3: 3}, maximise=True)
 
 
 @pytest.fixture
@@ -214,7 +215,9 @@ def test_collect_hyperdrive_metrics(metrics_df: pd.DataFrame, tmp_path: Path, ov
 
 @pytest.mark.parametrize('maximise', [True, False])
 def test_get_best_epochs(metrics_df: pd.DataFrame, maximise: bool) -> None:
-    best_epochs = get_best_epochs(metrics_df, 'val/accuracy', maximise=maximise)
+    max_epochs_dict = {0: 3, 1: 3, 3: 3}
+    best_epochs = get_best_epochs(metrics_df=metrics_df, primary_metric='val/accuracy',
+                                  max_epochs_dict=max_epochs_dict, maximise=maximise)
     assert list(best_epochs.keys()) == list(metrics_df.columns)
     assert all(isinstance(epoch, int) for epoch in best_epochs.values())
 


### PR DESCRIPTION
In this PR:
- Fix is introduced to handle missing cross-validation rounds (e.g., when a round fails)
- Extra validation epoch is handled
- Downloading the AML metrics json and saving it as a dataframe is separated into two functions (current version gives a `KeyError` when the json is downloaded for the first time)
