### PR TITLE
BUG: Remove all calls to get_ml_client outside v2

### DIFF
--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -261,7 +261,7 @@ class Runner:
             else:
                 hyperparam_args = self.lightning_container.get_hyperparam_args()
                 hyperdrive_config = None
-            ml_client = get_ml_client()
+            ml_client = get_ml_client() if not self.experiment_config.strictly_aml_v1 else None
 
             env_file = choose_conda_env_file(env_file=self.experiment_config.conda_env)
             logging.info(f"Using this Conda environment definition: {env_file}")


### PR DESCRIPTION
There was still another call to get_ml_client that was asking for credentials again preventing running on aml v1 strictly