### PR TITLE
BUG: Use permanent permalinks in docs to fix precommit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
   - id: check-added-large-files    # Prevent giant files from being committed
   - id: check-docstring-first      # Checks a common error of defining a docstring after code
   - id: check-merge-conflict       # Check for files that contain merge conflict strings
-  - id: check-vcs-permalinks       # Ensures that links to vcs websites are permalinks
   - id: detect-private-key         # Detects the presence of private keys
   - id: end-of-file-fixer          # Ensures that a file is either empty, or ends with one newline
   - id: trailing-whitespace        # This hook trims trailing whitespace

--- a/docs/source/checkpoints.md
+++ b/docs/source/checkpoints.md
@@ -2,7 +2,7 @@
 
 Hi-ml toolbox offers different utilities to parse and download pretrained checkpoints that help you abstract checkpoint
 downloading from different sources. Refer to
-[CheckpointParser](https://github.com/microsoft/hi-ml/blob/main/hi-ml/src/health_ml/utils/checkpoint_utils.py#L238) for
+[CheckpointParser](https://github.com/microsoft/hi-ml/blob/c4e25b8a797cfee3822bda1e1c05e399667bf68e/hi-ml/src/health_ml/utils/checkpoint_utils.py#L238) for
 more details on the supported checkpoints format. Here's how you can use the checkpoint parser depending on the source:
 
 - For a local path, simply pass it as shown below. The parser will further check if the provided path exists:
@@ -54,8 +54,8 @@ N.B: config.json should correspond to the original workspace where the AML run l
 ## Use cases
 
 CheckpointParser is used to specify a `src_checkpoint` to [resume training from a given
-checkpoint](https://github.com/microsoft/hi-ml/blob/main/docs/source/runner.md#L238),
-or [run inference with a pretrained model](https://github.com/microsoft/hi-ml/blob/main/docs/source/runner.md#L215),
+checkpoint](https://github.com/microsoft/hi-ml/blob/c4e25b8a797cfee3822bda1e1c05e399667bf68e/docs/source/runner.md#L238),
+or [run inference with a pretrained model](https://github.com/microsoft/hi-ml/blob/c4e25b8a797cfee3822bda1e1c05e399667bf68e/docs/source/runner.md#L215),
 as well as
-[ssl_checkpoint](https://github.com/microsoft/hi-ml/blob/main/hi-ml-cpath/src/health_cpath/utils/deepmil_utils.py#L62)
+[ssl_checkpoint](https://github.com/microsoft/hi-ml/blob/c4e25b8a797cfee3822bda1e1c05e399667bf68e/hi-ml-cpath/src/health_cpath/utils/deepmil_utils.py#L62)
 for computation pathology self supervised pretrained encoders.

--- a/docs/source/checkpoints.md
+++ b/docs/source/checkpoints.md
@@ -2,7 +2,7 @@
 
 Hi-ml toolbox offers different utilities to parse and download pretrained checkpoints that help you abstract checkpoint
 downloading from different sources. Refer to
-[CheckpointParser](https://github.com/microsoft/hi-ml/blob/c4e25b8a797cfee3822bda1e1c05e399667bf68e/hi-ml/src/health_ml/utils/checkpoint_utils.py#L238) for
+[CheckpointParser](https://github.com/microsoft/hi-ml/blob/main/hi-ml/src/health_ml/utils/checkpoint_utils.py#L238) for
 more details on the supported checkpoints format. Here's how you can use the checkpoint parser depending on the source:
 
 - For a local path, simply pass it as shown below. The parser will further check if the provided path exists:
@@ -54,8 +54,8 @@ N.B: config.json should correspond to the original workspace where the AML run l
 ## Use cases
 
 CheckpointParser is used to specify a `src_checkpoint` to [resume training from a given
-checkpoint](https://github.com/microsoft/hi-ml/blob/c4e25b8a797cfee3822bda1e1c05e399667bf68e/docs/source/runner.md#L238),
-or [run inference with a pretrained model](https://github.com/microsoft/hi-ml/blob/c4e25b8a797cfee3822bda1e1c05e399667bf68e/docs/source/runner.md#L215),
+checkpoint](https://github.com/microsoft/hi-ml/blob/main/docs/source/runner.md#L238),
+or [run inference with a pretrained model](https://github.com/microsoft/hi-ml/blob/main/docs/source/runner.md#L215),
 as well as
-[ssl_checkpoint](https://github.com/microsoft/hi-ml/blob/c4e25b8a797cfee3822bda1e1c05e399667bf68e/hi-ml-cpath/src/health_cpath/utils/deepmil_utils.py#L62)
+[ssl_checkpoint](https://github.com/microsoft/hi-ml/blob/main/hi-ml-cpath/src/health_cpath/utils/deepmil_utils.py#L62)
 for computation pathology self supervised pretrained encoders.


### PR DESCRIPTION
Fixes this https://results.[pre-commit.ci](https://results.pre-commit.ci/run/github/382004101/1668608031.nWPPLzbPRtmEbrD7tUrs0Q)/run/github/382004101/1668608031.nWPPLzbPRtmEbrD7tUrs0Q