### PR TITLE
DOC: Refer to CONTRIBUTING for list valid prefixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Please make sure to follow all the tasks in the checklist below. Then, delete th
 Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:
 
 - Ensure that your PR is small, and implements one change
-- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/CONTRIBUTING.md))
+- Give your PR title one of the prefixes listed in [CONTRIBUTING](/CONTRIBUTING.md#pull-request-titles) to indicate what type of change that is
 - Link the correct GitHub issue for tracking
 - Add unit tests for all functions that you introduced or modified
 - Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Please make sure to follow all the tasks in the checklist below. Then, delete th
 Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/CONTRIBUTING.md). Checklist:
 
 - Ensure that your PR is small, and implements one change
-- Give your PR title one of the prefixes listed in [CONTRIBUTING](/CONTRIBUTING.md#pull-request-titles) to indicate what type of change that is
+- Give your PR title one of the prefixes listed in [CONTRIBUTING](../docs/source/coding_guidelines.md#pull-request-titles) to indicate what type of change that is
 - Link the correct GitHub issue for tracking
 - Add unit tests for all functions that you introduced or modified
 - Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)


### PR DESCRIPTION
The list of valid prefixes is out of date. Instead of manually syncing with the docs, I propose linking to them.