### PR TITLE
BUG: Fix broken `--azureml` flag

### DIFF
--- a/hi-ml-azure/src/health_azure/examples/elevate_this.py
+++ b/hi-ml-azure/src/health_azure/examples/elevate_this.py
@@ -26,7 +26,8 @@ def main() -> None:
     _ = submit_to_azure_if_needed(
         compute_cluster_name="lite-testing-ds2",
         wait_for_completion=True,
-        wait_for_completion_show_output=True)
+        wait_for_completion_show_output=True,
+        strictly_aml_v1=True)
 
     parser = ArgumentParser()
     parser.add_argument("-m", "--message", type=str, required=True, help="The message to print out")

--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -831,6 +831,8 @@ def submit_to_azure_if_needed(  # type: ignore
             return _generate_v2_azure_datasets(cleaned_input_datasets, cleaned_output_datasets)
     # This codepath is reached when executing outside AzureML. Here we first check if a script submission to AzureML
     # is necessary. If not, return to the caller for local execution.
+    if submit_to_azureml is None:
+        submit_to_azureml = AZUREML_COMMANDLINE_FLAG in sys.argv[1:]
     if not submit_to_azureml:
         # Set the environment variables for local execution.
         environment_variables = {

--- a/hi-ml-azure/testazure/testazure/test_data/simple/hello_world_template.txt
+++ b/hi-ml-azure/testazure/testazure/test_data/simple/hello_world_template.txt
@@ -52,7 +52,7 @@ def main() -> None:
         wait_for_completion={{ wait_for_completion }},
         wait_for_completion_show_output={{ wait_for_completion_show_output }},
         tags={{ tags }},
-        submit_to_azureml={{ submit_to_azureml}},
+        submit_to_azureml={{ submit_to_azureml }},
         strictly_aml_v1={{ strictly_aml_v1 }})
 
     parser = ArgumentParser()


### PR DESCRIPTION
Closes #690.

Adds back in accidentally-removed `--azureml` flag logic and adds test to catch it breaking in the future.