### PR TITLE
BUG: Fix slow-path warning in tests that use MockPandaSlidesGenerator

### DIFF
--- a/hi-ml-cpath/testhisto/testhisto/datamodules/test_slides_datamodule.py
+++ b/hi-ml-cpath/testhisto/testhisto/datamodules/test_slides_datamodule.py
@@ -26,10 +26,12 @@ from testhisto.mocks.slides_generator import MockPandaSlidesGenerator, MockHisto
 no_gpu = not is_gpu_available()
 
 
-def get_loading_params(level: int = 0, roi_type: ROIType = ROIType.FOREGROUND) -> LoadingParams:
+def get_loading_params(
+    level: int = 0, roi_type: ROIType = ROIType.FOREGROUND, backend: WSIBackend = WSIBackend.CUCIM
+) -> LoadingParams:
     return LoadingParams(
         level=level,
-        backend=WSIBackend.CUCIM,
+        backend=backend,
         roi_type=roi_type,
         foreground_threshold=255,
         margin=0,
@@ -91,8 +93,9 @@ def get_original_tile(mock_dir: Path, wsi_id: str) -> np.ndarray:
 
 @pytest.mark.skipif(no_gpu, reason="Test requires GPU")
 @pytest.mark.gpu
-@pytest.mark.parametrize("roi_type", [ROIType.FOREGROUND, ROIType.WHOLE])
-def test_tiling_on_the_fly(roi_type: ROIType, mock_panda_slides_root_dir_diagonal: Path) -> None:
+@pytest.mark.parametrize('roi_type', [ROIType.FOREGROUND, ROIType.WHOLE])
+@pytest.mark.parametrize('backend', [WSIBackend.CUCIM, WSIBackend.OPENSLIDE])
+def test_tiling_on_the_fly(roi_type: ROIType, backend: WSIBackend, mock_panda_slides_root_dir_diagonal: Path) -> None:
     batch_size = 1
     tile_count = 16
     tile_size = 28
@@ -103,7 +106,7 @@ def test_tiling_on_the_fly(roi_type: ROIType, mock_panda_slides_root_dir_diagona
         batch_size=batch_size,
         max_bag_size=tile_count,
         tiling_params=TilingParams(tile_size=28),
-        loading_params=get_loading_params(level=0, roi_type=roi_type),
+        loading_params=get_loading_params(level=0, roi_type=roi_type, backend=backend),
     )
     dataloader = datamodule.train_dataloader()
     for sample in dataloader:

--- a/hi-ml-cpath/testhisto/testhisto/mocks/slides_generator.py
+++ b/hi-ml-cpath/testhisto/testhisto/mocks/slides_generator.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Tuple, List, Union
 import numpy as np
 import pandas as pd
 import torch
-from tifffile import TiffWriter
+from tifffile.tifffile import TiffWriter, PHOTOMETRIC, COMPRESSION
 from torch import Tensor
 from health_cpath.datasets.panda_dataset import PandaDataset
 from testhisto.mocks.base_data_generator import MockHistoDataGenerator, MockHistoDataType, PANDA_N_CLASSES
@@ -178,7 +178,13 @@ class MockPandaSlidesGenerator(MockHistoDataGenerator):
         :param wsi_levels: List of whole slide images of different resolution levels in channels_last format.
         """
         with TiffWriter(file_path, bigtiff=True) as tif:
-            options = dict(photometric="rgb", compression="zlib")
+            options = dict(
+                software='tifffile',
+                metadata={'axes': 'YXC'},
+                photometric=PHOTOMETRIC.RGB,
+                compression=COMPRESSION.ADOBE_DEFLATE,  # ADOBE_DEFLATE aka ZLIB lossless compression
+                tile=(16, 16),
+            )
             for i, wsi_level in enumerate(wsi_levels):
                 # the subfiletype parameter is a bitfield that determines if the wsi_level is a reduced version of
                 # another image.


### PR DESCRIPTION
Closes #716 
Test with OpenSlide backend as well now that the tiffiles are not corrupted anymore -> properly compressed and saved in chunks by specifying tile_size in tiffwriter options