### PR TITLE
ENH: Allow low-priority preemption after training

### DIFF
--- a/docs/source/checkpoints.md
+++ b/docs/source/checkpoints.md
@@ -13,7 +13,7 @@ from health_ml.utils.checpoint_utils import CheckpointParser
 download_dir = 'outputs/checkpoints'
 checkpoint_parser = CheckpointParser(checkpoint='local/path/to/my_checkpoint/model.ckpt')
 print('Checkpoint', checkpoint_parser.checkpoint, 'is a local file', checkpoint_parser.is_local_file)
-local_file = parser.get_path(download_dir)
+local_file = parser.get_or_download_checkpoint(download_dir)
 ```
 
 - To download a checkpoint from a URL:
@@ -25,7 +25,7 @@ download_dir = 'outputs/checkpoints'
 checkpoint_parser = CheckpointParser('https://my_checkpoint_url.com/model.ckpt')
 print('Checkpoint', checkpoint_parser.checkpoint, 'is a URL', checkpoint_parser.is_url)
 # will dowload the checkpoint to download_dir/MODEL_WEIGHTS_DIR_NAME
-path_to_ckpt = checkpoint_parser.get_path(download_dir)
+path_to_ckpt = checkpoint_parser.get_or_download_checkpoint(download_dir)
 ```
 
 - Finally checkpoints from an Azure ML runs can be reused by providing an id in this format
@@ -39,7 +39,7 @@ from health_ml.utils.checpoint_utils import CheckpointParser
 
 checkpoint_parser = CheckpointParser('AzureML_run_id:best.ckpt')
 print('Checkpoint', checkpoint_parser.checkpoint, 'is a AML run', checkpoint_parser.is_aml_run_id)
-path_azure_ml_ckpt = checkpoint_parser.get_path(download_dir)
+path_azure_ml_ckpt = checkpoint_parser.get_or_download_checkpoint(download_dir)
 ```
 
 If the Azure ML run is in a different workspace, a temporary SAS URL to download the checkpoint can be generated as follow:

--- a/hi-ml-azure/src/health_azure/package_setup.py
+++ b/hi-ml-azure/src/health_azure/package_setup.py
@@ -35,7 +35,7 @@ def health_azure_package_setup() -> None:
         "msal": logging.INFO,
         "msrest": logging.INFO,
         # Urllib3 prints out connection information for each call to write metrics, etc
-        "urlib3": logging.INFO,
+        "urllib3": logging.INFO,
     }
     set_logging_levels(module_levels)
     # PyJWT prints out warnings that are beyond our control

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1474,12 +1474,12 @@ def download_files_by_suffix(
     :param validate_checksum: Whether to validate the content from HTTP response
     :return: An Iterable with all downloaded files.
     """
-    for f in get_run_file_names(run):
-        if f.endswith(suffix):
-            logging.info(f"Downloading file {f}")
+    for file in get_run_file_names(run):
+        if file.endswith(suffix):
+            logging.info(f"Downloading file {file}")
             output_folder.mkdir(parents=True, exist_ok=True)
-            output_file = output_folder / f
-            _download_file_from_run(run, f, output_file, validate_checksum=validate_checksum)
+            output_file = output_folder / file
+            _download_file_from_run(run, file, output_file, validate_checksum=validate_checksum)
             yield output_file
 
 

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -1458,6 +1458,31 @@ def download_files_from_run_id(
     torch_barrier()
 
 
+def download_files_by_suffix(
+    run: Run,
+    output_folder: Path,
+    suffix: str,
+    validate_checksum: bool = False
+) -> Iterable[Path]:
+    """Downloads all files from an AzureML run that have a given suffix, into a folder. The function returns an
+    Iterable, where a file path is emitted right after it has been downloaded.
+
+    :param run: The AzureML run from where the files should be downloaded.
+    :param suffix: The suffix for all files that should be returned.
+    :param output_folder: The folder where the files should be downloaded to. If a file `foo/bar.txt` is downloaded,
+        it will be downloaded as `<output_folder>/foo/bar.txt`.
+    :param validate_checksum: Whether to validate the content from HTTP response
+    :return: An Iterable with all downloaded files.
+    """
+    for f in get_run_file_names(run):
+        if f.endswith(suffix):
+            logging.info(f"Downloading file {f}")
+            output_folder.mkdir(parents=True, exist_ok=True)
+            output_file = output_folder / f
+            _download_file_from_run(run, f, output_file, validate_checksum=validate_checksum)
+            yield output_file
+
+
 def get_driver_log_file_text(run: Run, download_file: bool = True) -> Optional[str]:
     """
     Returns text stored in run log driver file.

--- a/hi-ml-azure/testazure/testazure/test_azure_util.py
+++ b/hi-ml-azure/testazure/testazure/test_azure_util.py
@@ -13,7 +13,7 @@ import time
 from argparse import ArgumentParser, Namespace, ArgumentError
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
 from unittest import mock
 from unittest.mock import DEFAULT, MagicMock, patch
 from uuid import uuid4
@@ -36,8 +36,14 @@ from azureml.data.azure_storage_datastore import AzureBlobDatastore
 
 import health_azure.utils as util
 from health_azure.himl import AML_IGNORE_FILE, append_to_amlignore, effective_experiment_name
-from health_azure.utils import (ENV_MASTER_ADDR, ENV_MASTER_PORT, MASTER_PORT_DEFAULT,
-                                PackageDependency, create_argparser, get_credential, download_file_if_necessary)
+from health_azure.utils import (ENV_MASTER_ADDR,
+                                ENV_MASTER_PORT,
+                                MASTER_PORT_DEFAULT,
+                                PackageDependency,
+                                create_argparser,
+                                download_files_by_suffix,
+                                get_credential,
+                                download_file_if_necessary)
 from testazure.test_himl import RunTarget, render_and_run_test_script
 from testazure.utils_testazure import (DEFAULT_IGNORE_FOLDERS,
                                        DEFAULT_WORKSPACE,
@@ -2586,3 +2592,19 @@ def test_download_from_run_if_necessary_rank_nonzero(tmp_path: Path) -> None:
         local_path = download_file_if_necessary(run, remote_filename, expected_local_path)
         assert local_path is not None
         run.download_file.assert_not_called()
+
+
+@pytest.mark.parametrize('files', [[], ["a.txt", "b.txt", "c.txt"]])
+def test_download_files_by_suffix(tmp_path: Path, files: List[str]) -> None:
+    def mock_download(run: Run, file: str, output_file: Path, validate_checksum: bool) -> None:
+        output_file.write_text("mock content")
+
+    with mock.patch("health_azure.utils.get_run_file_names", return_value=files):
+        with mock.patch("health_azure.utils._download_file_from_run", side_effect=mock_download):
+            downloaded = download_files_by_suffix("outputs", tmp_path, ".txt")
+            assert isinstance(downloaded, Generator)
+            downloaded_list = list(downloaded)
+            assert len(downloaded_list) == len(files)
+            for f in downloaded_list:
+                assert f.is_file()
+                assert str(f).startswith(str(tmp_path))

--- a/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
@@ -19,11 +19,9 @@ from health_cpath.preprocessing.loading import LoadingParams
 from health_cpath.utils.callbacks import LossAnalysisCallback, LossCallbackParams
 from health_cpath.utils.wsi_utils import TilingParams
 
-from health_ml.utils import fixed_paths
 from health_ml.deep_learning_config import OptimizerParams
 from health_ml.lightning_container import LightningContainer
-from health_ml.utils.checkpoint_utils import get_best_checkpoint_path, CheckpointParser
-from health_ml.utils.common_utils import DEFAULT_AML_CHECKPOINT_DIR
+from health_ml.utils.checkpoint_utils import CheckpointParser
 
 from health_cpath.datamodules.base_module import CacheLocation, CacheMode, HistoDataModule
 from health_cpath.datasets.base_dataset import SlidesDataset

--- a/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
@@ -183,31 +183,11 @@ class BaseMIL(LightningContainer, LoadingParams, EncoderParams, PoolingParams, C
     def get_checkpoint_to_test(self) -> Path:
         """
         Returns the full path to a checkpoint file that was found to be best during training, whatever criterion
-        was applied there. This is necessary since for some models the checkpoint is in a subfolder of the checkpoint
-        folder.
+        was applied there. Note that the checkpoint file might not (yet) exist, for example in the case of
+        preempted jobs.
         """
-        # absolute path is required for registering the model.
-        absolute_checkpoint_path = Path(fixed_paths.repository_root_directory(),
-                                        DEFAULT_AML_CHECKPOINT_DIR,
-                                        self.best_checkpoint_filename_with_suffix)
-        if absolute_checkpoint_path.is_file():
-            return absolute_checkpoint_path
-
-        absolute_checkpoint_path_parent = Path(fixed_paths.repository_root_directory().parent,
-                                               DEFAULT_AML_CHECKPOINT_DIR,
-                                               self.best_checkpoint_filename_with_suffix)
-        if absolute_checkpoint_path_parent.is_file():
-            return absolute_checkpoint_path_parent
-
         checkpoint_path = Path(self.checkpoint_folder, self.best_checkpoint_filename_with_suffix)
-        if checkpoint_path.is_file():
-            return checkpoint_path
-
-        checkpoint_path = get_best_checkpoint_path(self.checkpoint_folder)
-        if checkpoint_path.is_file():
-            return checkpoint_path
-
-        raise ValueError("Path to best checkpoint not found")
+        return checkpoint_path
 
     def get_dataloader_kwargs(self) -> dict:
         num_cpus = os.cpu_count()

--- a/hi-ml-cpath/src/health_cpath/utils/deepmil_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/deepmil_utils.py
@@ -98,7 +98,7 @@ class EncoderParams(param.Parameterized):
         elif self.encoder_type == SSLEncoder.__name__:
             assert outputs_folder is not None, "outputs_folder cannot be None for SSLEncoder"
             encoder = SSLEncoder(
-                pl_checkpoint_path=self.ssl_checkpoint.get_path(outputs_folder),
+                pl_checkpoint_path=self.ssl_checkpoint.get_or_download_checkpoint(outputs_folder),
                 tile_size=self.tile_size,
                 n_channels=self.n_channels,
             )

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_deepmil_utils.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_deepmil_utils.py
@@ -32,7 +32,7 @@ def test_load_ssl_checkpoint_from_local_file(tmp_path: Path) -> None:
         encoder_type=SSLEncoder.__name__, ssl_checkpoint=CheckpointParser(str(local_checkpoint_path))
     )
     assert encoder_params.ssl_checkpoint.is_local_file
-    ssl_checkpoint_path = encoder_params.ssl_checkpoint.get_path(tmp_path)
+    ssl_checkpoint_path = encoder_params.ssl_checkpoint.get_or_download_checkpoint(tmp_path)
     assert ssl_checkpoint_path.exists()
     assert ssl_checkpoint_path == local_checkpoint_path
     with patch("health_cpath.models.encoders.SSLEncoder._get_encoder") as mock_get_encoder:
@@ -50,7 +50,7 @@ def test_load_ssl_checkpoint_from_url(tmp_path: Path) -> None:
         aml_workspace=DEFAULT_WORKSPACE.workspace)
     encoder_params = EncoderParams(encoder_type=SSLEncoder.__name__, ssl_checkpoint=CheckpointParser(blob_url))
     assert encoder_params.ssl_checkpoint.is_url
-    ssl_checkpoint_path = encoder_params.ssl_checkpoint.get_path(tmp_path)
+    ssl_checkpoint_path = encoder_params.ssl_checkpoint.get_or_download_checkpoint(tmp_path)
     assert ssl_checkpoint_path.exists()
     assert ssl_checkpoint_path == tmp_path / MODEL_WEIGHTS_DIR_NAME / LAST_CHECKPOINT_FILE_NAME
     encoder = encoder_params.get_encoder(tmp_path)
@@ -63,7 +63,7 @@ def test_load_ssl_checkpoint_from_run_id(tmp_path: Path) -> None:
     assert encoder_params.ssl_checkpoint.is_aml_run_id
     with patch("health_ml.utils.checkpoint_utils.get_workspace") as mock_get_workspace:
         mock_get_workspace.return_value = DEFAULT_WORKSPACE.workspace
-        ssl_checkpoint_path = encoder_params.ssl_checkpoint.get_path(tmp_path)
+        ssl_checkpoint_path = encoder_params.ssl_checkpoint.get_or_download_checkpoint(tmp_path)
         assert ssl_checkpoint_path.exists()
         assert ssl_checkpoint_path == tmp_path / TEST_SSL_RUN_ID / LAST_CHECKPOINT
         encoder = encoder_params.get_encoder(tmp_path)

--- a/hi-ml/src/health_ml/run_ml.py
+++ b/hi-ml/src/health_ml/run_ml.py
@@ -153,10 +153,6 @@ class MLRunner:
 
         # configure recovery container if provided
         self.checkpoint_handler.download_recovery_checkpoints_or_weights()  # type: ignore
-        # Handling low-priority preemption: If we are recovering from a preemption that appeared after training was
-        # finished, there will not be an inference checkpoint available on disk. In that case, we need to download
-        # it from the AzureML run.
-        self.checkpoint_handler.download_inference_checkpoint()
 
         self.container.setup()
         self.container.create_lightning_module_and_store()

--- a/hi-ml/src/health_ml/run_ml.py
+++ b/hi-ml/src/health_ml/run_ml.py
@@ -153,6 +153,10 @@ class MLRunner:
 
         # configure recovery container if provided
         self.checkpoint_handler.download_recovery_checkpoints_or_weights()  # type: ignore
+        # Handling low-priority preemption: If we are recovering from a preemption that appeared after training was
+        # finished, there will not be an inference checkpoint available on disk. In that case, we need to download
+        # it from the AzureML run.
+        self.checkpoint_handler.download_inference_checkpoint()
 
         self.container.setup()
         self.container.create_lightning_module_and_store()

--- a/hi-ml/src/health_ml/utils/checkpoint_handler.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_handler.py
@@ -52,9 +52,9 @@ class CheckpointHandler:
         """
         if is_global_rank_zero():
             checkpoints = list(self.container.checkpoint_folder.rglob("*"))
-            logging.info(f"Available checkpoints: {len(checkpoints)}")
+            logging.info(f"Number of checkpoints in the checkpoint folder: {len(checkpoints)}")
             for f in checkpoints:
-                logging.info(f)
+                logging.info(f.relative_to(self.container.checkpoint_folder))
         return find_recovery_checkpoint_on_disk_or_cloud(self.container.checkpoint_folder)
 
     def get_checkpoint_to_test(self) -> Path:

--- a/hi-ml/src/health_ml/utils/checkpoint_handler.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_handler.py
@@ -114,9 +114,12 @@ class CheckpointHandler:
         For low-priority preemption that occured after training, try to download the inference checkpoint if that
         is available in the AzureML run from a previous incarnation of the job. Downloads go into the `download_folder`.
 
+        The method returns None if no checkpoint was found, or if the
+        current code is executing outside of AzureML and hence can't access previous inference checkpoints in AzureML.
+
         :param download_folder: The folder where the checkpoints should be downloaded to. If not provided, use a
             temp folder.
-        :return: The path to a downloaded inference checkpoint.
+        :return: The path to a downloaded inference checkpoint, or None if no checkpoint was available.
         """
         # This logic will only trigger in AzureML. Download should only happen once per node.
         if is_running_in_azure_ml() and is_global_rank_zero():

--- a/hi-ml/src/health_ml/utils/checkpoint_handler.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_handler.py
@@ -59,7 +59,7 @@ class CheckpointHandler:
         """
         if is_global_rank_zero():
             checkpoints = list(self.container.checkpoint_folder.rglob("*"))
-            logging.info(f"Number of checkpoints in the checkpoint folder: {len(checkpoints)}")
+            logging.info(f"There are {len(checkpoints)} checkpoints in the checkpoint folder:")
             for f in checkpoints:
                 logging.info(f.relative_to(self.container.checkpoint_folder))
         return find_recovery_checkpoint_on_disk_or_cloud(self.container.checkpoint_folder)

--- a/hi-ml/src/health_ml/utils/checkpoint_handler.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_handler.py
@@ -117,4 +117,4 @@ class CheckpointHandler:
             else:
                 destination = self.container.get_checkpoint_to_test()
                 destination.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(highest_epoch_checkpoint, destination)
+                shutil.move(str(highest_epoch_checkpoint), str(destination))

--- a/hi-ml/src/health_ml/utils/checkpoint_handler.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_handler.py
@@ -32,7 +32,8 @@ class CheckpointHandler:
         This is called at the start of training.
         """
         if self.container.src_checkpoint:
-            self.trained_weights_path = self.container.src_checkpoint.get_or_download_checkpoint(self.container.checkpoint_folder)
+            self.trained_weights_path = self.container.src_checkpoint.get_or_download_checkpoint(
+                download_dir=self.container.checkpoint_folder)
             self.container.trained_weights_path = self.trained_weights_path
 
     def additional_training_done(self) -> None:

--- a/hi-ml/src/health_ml/utils/checkpoint_handler.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_handler.py
@@ -4,7 +4,6 @@
 #  -------------------------------------------------------------------------------------------
 
 import logging
-import shutil
 import tempfile
 from azureml.core import Run
 from pathlib import Path
@@ -81,12 +80,12 @@ class CheckpointHandler:
             # Handling low-priority preemption: If we are recovering from a preemption that appeared after training was
             # finished, there will not be an inference checkpoint available on disk. In that case, we need to download
             # it from the AzureML run.
-            logging.info(f"Trying to find an inference checkpoint in AzureML.")
+            logging.info("Trying to find an inference checkpoint in AzureML.")
             downloaded_checkpoint = self.download_inference_checkpoint()
             if downloaded_checkpoint is not None:
                 logging.info(f"Using a checkpoint found in the AzureML run: {downloaded_checkpoint}")
                 return downloaded_checkpoint
-            raise FileNotFoundError(f"No inference checkpoint file found locally nor in AzureML.")
+            raise FileNotFoundError("No inference checkpoint file found locally nor in AzureML.")
         elif self.trained_weights_path:
             # Model was not trained, check if there is a local weight path.
             logging.info(f"Using pre-trained weights from {self.trained_weights_path}")

--- a/hi-ml/src/health_ml/utils/checkpoint_handler.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_handler.py
@@ -32,7 +32,7 @@ class CheckpointHandler:
         This is called at the start of training.
         """
         if self.container.src_checkpoint:
-            self.trained_weights_path = self.container.src_checkpoint.get_path(self.container.checkpoint_folder)
+            self.trained_weights_path = self.container.src_checkpoint.get_or_download_checkpoint(self.container.checkpoint_folder)
             self.container.trained_weights_path = self.trained_weights_path
 
     def additional_training_done(self) -> None:

--- a/hi-ml/src/health_ml/utils/checkpoint_utils.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_utils.py
@@ -215,6 +215,7 @@ def find_checkpoint_with_highest_epoch(files: Iterable[Path], delete_files: bool
                 logging.debug(f"Deleting checkpoint file {file_with_highest_epoch}")
                 file_with_highest_epoch.unlink()
             return epoch, file
+        assert file_with_highest_epoch is not None
         return highest_epoch, file_with_highest_epoch
 
     highest_epoch: Optional[int] = None

--- a/hi-ml/src/health_ml/utils/checkpoint_utils.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_utils.py
@@ -383,7 +383,7 @@ class CheckpointParser:
                     file.write(chunk)
         return checkpoint_path
 
-    def get_path(self, download_dir: Path) -> Path:
+    def get_or_download_checkpoint(self, download_dir: Path) -> Path:
         """Returns the path to the checkpoint file. If the checkpoint is a URL, it will be downloaded to the checkpoints
         folder. If the checkpoint is an AzureML run ID, it will be downloaded from the run to the checkpoints folder.
         If the checkpoint is a local file, it will be returned as is.

--- a/hi-ml/src/health_ml/utils/checkpoint_utils.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_utils.py
@@ -134,7 +134,7 @@ def download_checkpoints_from_run(run: Run, tmp_folder: Optional[Path] = None) -
 
 def download_highest_epoch_checkpoint(run: Run, checkpoint_suffix: str, output_folder: Path) -> Optional[Path]:
     """Downloads all checkpoint files from the run that have a given suffix, and returns the local path to the
-    downloaded checkpoint with the highest epoch. Checkpoints are downloaded one-by-one and delete right away
+    downloaded checkpoint with the highest epoch. Checkpoints are downloaded one-by-one and deleted right away
     if they are not the highest epoch.
 
     :param run: The AzureML run from where the files should be downloaded.

--- a/hi-ml/src/health_ml/utils/checkpoint_utils.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_utils.py
@@ -12,7 +12,7 @@ import requests
 import torch
 
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Tuple
 from urllib.parse import urlparse
 from azureml.core import Run
 
@@ -198,7 +198,7 @@ def find_checkpoint_with_highest_epoch(files: Iterable[Path], delete_files: bool
         file: Path,
         highest_epoch: Optional[int],
         file_with_highest_epoch: Optional[Path]
-    ) -> None:
+    ) -> Tuple[int, Path]:
         """Reads the epoch number from the given `file`, and returns updated information about which file
         has been found to have the highest epoch number.
 

--- a/hi-ml/src/health_ml/utils/checkpoint_utils.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_utils.py
@@ -143,7 +143,7 @@ def find_recovery_checkpoint_on_disk_or_cloud(path: Path) -> Optional[Path]:
     recovery_checkpoint = find_local_recovery_checkpoint(path)
     if recovery_checkpoint is None and is_running_in_azure_ml():
         logging.info(
-            "No checkpoints available in the checkpoint folder. Trying to find checkpoints in AzureML.")
+            "No recovery checkpoints available in the checkpoint folder. Trying to find checkpoints in AzureML.")
         # Download checkpoints from AzureML, then try to find recovery checkpoints among those.
         # Downloads should go to a temporary folder because downloading the files to the checkpoint
         # folder might cause artifact conflicts later.

--- a/hi-ml/src/health_ml/utils/checkpoint_utils.py
+++ b/hi-ml/src/health_ml/utils/checkpoint_utils.py
@@ -211,7 +211,7 @@ def find_recovery_checkpoint_in_downloaded_files(path: Path) -> Optional[Path]:
     :return: The checkpoint file with the highest epoch number, or None if no such file was found.
     """
     candidates = path.glob(f"**/*{CHECKPOINT_SUFFIX}")
-    return find_checkpoint_with_highest_epoch(candidates)
+    return find_checkpoint_with_highest_epoch(candidates, delete_files=False)
 
 
 def cleanup_checkpoints(ckpt_folder: Path) -> None:

--- a/hi-ml/testhiml/testhiml/test_checkpoints.py
+++ b/hi-ml/testhiml/testhiml/test_checkpoints.py
@@ -389,6 +389,7 @@ def test_download_inference_checkpoint(tmp_path: Path) -> None:
                                  download_highest_epoch_checkpoint=mock_download_highest_epoch_checkpoint):
             downloaded = handler.download_inference_checkpoint(download_folder=tmp_path)
             mock_download_highest_epoch_checkpoint.assert_called_once()
+            assert downloaded is not None
             assert downloaded.is_file()
             assert _load_epoch_from_checkpoint(downloaded) == epoch
 

--- a/hi-ml/testhiml/testhiml/test_checkpoints.py
+++ b/hi-ml/testhiml/testhiml/test_checkpoints.py
@@ -157,9 +157,8 @@ def test_custom_checkpoint_for_test(tmp_path: Path) -> None:
     does_not_exist = Path("does_not_exist")
     with mock.patch("health_ml.configs.hello_world.HelloWorld.get_checkpoint_to_test") as mock2:
         mock2.return_value = does_not_exist
-        with pytest.raises(FileNotFoundError) as ex:
+        with pytest.raises(FileNotFoundError):
             checkpoint_handler.get_checkpoint_to_test()
-        assert str(does_not_exist) in str(ex)
         mock2.assert_called_once()
 
 

--- a/hi-ml/testhiml/testhiml/test_checkpoints.py
+++ b/hi-ml/testhiml/testhiml/test_checkpoints.py
@@ -157,7 +157,7 @@ def test_custom_checkpoint_for_test(tmp_path: Path) -> None:
     does_not_exist = Path("does_not_exist")
     with mock.patch("health_ml.configs.hello_world.HelloWorld.get_checkpoint_to_test") as mock2:
         mock2.return_value = does_not_exist
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="No inference checkpoint file found"):
             checkpoint_handler.get_checkpoint_to_test()
         mock2.assert_called_once()
 

--- a/hi-ml/testhiml/testhiml/test_checkpoints.py
+++ b/hi-ml/testhiml/testhiml/test_checkpoints.py
@@ -364,7 +364,7 @@ def test_download_inference_checkpoint(tmp_path: Path) -> None:
     relative_checkpoint_path = f"{CHECKPOINT_FOLDER}/{LAST_CHECKPOINT_FILE_NAME}"
     assert str(handler.get_relative_inference_checkpoint_path()) == relative_checkpoint_path
     # This test is not running in AzureML, so trying to download inference checkpoints from the current run should
-    # be a no-ope.
+    # be a no-op.
     handler.download_inference_checkpoint()
 
     with mock.patch.multiple("health_ml.utils.checkpoint_handler",


### PR DESCRIPTION
Jobs that get interrupted after training and then re-start will not find an inference checkpoint and fail. This PR adds logic to search for that checkpoint in AzureML.

Closes #701 