### PR TITLE
ENH: Simplify makefile targets

### DIFF
--- a/.github/workflows/hi-ml-pr.yml
+++ b/.github/workflows/hi-ml-pr.yml
@@ -130,6 +130,7 @@ jobs:
         run: |
           cd ${{ matrix.folder }}
 
+          make pip_test
           # Install local package in editable mode
           make pip_local
 
@@ -315,6 +316,7 @@ jobs:
           cd ${{ matrix.folder }}
 
           make pip_upgrade
+          make pip_test
 
           while ! pip install ${{ steps.download.outputs.package_version }}
           do

--- a/.github/workflows/hi-ml-pr.yml
+++ b/.github/workflows/hi-ml-pr.yml
@@ -56,7 +56,9 @@ jobs:
           python-version: ${{ env.pythonVersion }}
 
       - name: flake8
-        run: make flake8
+        run: |
+          make pip_test
+          make flake8
 
   himl-mypy:
     runs-on: ubuntu-20.04
@@ -71,7 +73,9 @@ jobs:
           python-version: ${{ env.pythonVersion }}
 
       - name: mypy
-        run: make mypy
+        run: |
+          make pip_test
+          make mypy
 
   himl-pyright:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -80,18 +80,12 @@ pyright: conda call_pyright
 check: flake8 mypy
 
 # run pytest on package, assuming test requirements already installed
-call_pytest:
-	$(call call_packages,call_pytest)
-
-# install test requirements and run tests
-pytest: pip_test call_pytest
+pytest:
+	$(call call_packages,pytest)
 
 # run pytest fast subset on package, assuming test requirements already installed
-call_pytest_fast:
-	$(call call_packages,call_pytest_fast)
-
-# install test requirements and run pytest fast subset
-pytest_fast: pip_test call_pytest_fast
+pytest_fast:
+	$(call call_packages,pytest_fast)
 
 # run pytest with coverage on package, and format coverage output as a text file, assuming test requirements already installed
 call_pytest_and_coverage:

--- a/Makefile
+++ b/Makefile
@@ -61,18 +61,12 @@ call_build:
 build: pip_build call_build
 
 # run flake8, assuming test requirements already installed
-call_flake8:
-	$(call call_packages,call_flake8)
-
-# pip install test requirements and run flake8
-flake8: pip_test call_flake8
+flake8:
+	$(call call_packages,flake8)
 
 # run mypy, assuming test requirements already installed
-call_mypy:
-	$(call call_packages,call_mypy)
-
-# pip install test requirements and run mypy
-mypy: pip_test call_mypy
+mypy:
+	$(call call_packages,mypy)
 
 # run pyright, assuming test requirements already installed
 call_pyright:
@@ -82,11 +76,8 @@ call_pyright:
 # conda install test requirements and run pyright
 pyright: conda call_pyright
 
-# run basic checks
-call_check: call_flake8 call_mypy
-
-# install test requirements and run basic checks
-check: pip_test call_check
+# run basic checks, assuming test requirements already installed
+check: flake8 mypy
 
 # run pytest on package, assuming test requirements already installed
 call_pytest:

--- a/hi-ml-azure/Makefile
+++ b/hi-ml-azure/Makefile
@@ -59,18 +59,12 @@ mypy:
 check: flake8 mypy
 
 # run pytest on package, assuming test requirements already installed
-call_pytest:
+pytest:
 	pytest testazure
 
-# install test requirements and run tests
-pytest: pip_test call_pytest
-
 # run pytest fast subset on package, assuming test requirements already installed
-call_pytest_fast:
+pytest_fast:
 	pytest -m fast testazure
-
-# install test requirements and run pytest fast subset
-pytest_fast: pip_test call_pytest_fast
 
 # run pytest with coverage on package
 call_pytest_and_coverage:

--- a/hi-ml-azure/Makefile
+++ b/hi-ml-azure/Makefile
@@ -46,26 +46,17 @@ call_build:
 build: pip_build call_build
 
 # run flake8, assuming test requirements already installed
-call_flake8:
+flake8:
 	flake8 --count --statistics .
 
-# pip install test requirements and run flake8
-flake8: pip_test call_flake8
-
 # run mypy, assuming test requirements already installed
-call_mypy:
+mypy:
 	mypy --install-types --show-error-codes --non-interactive setup.py
 	mypy --install-types --show-error-codes --non-interactive --package health_azure
 	mypy --install-types --show-error-codes --non-interactive --package testazure
 
-# pip install test requirements and run mypy
-mypy: pip_test call_mypy
-
-# run basic checks
-call_check: call_flake8 call_mypy
-
-# install test requirements and run basic checks
-check: pip_test call_check
+# run basic checks, assuming test requirements already installed
+check: flake8 mypy
 
 # run pytest on package, assuming test requirements already installed
 call_pytest:

--- a/hi-ml/Makefile
+++ b/hi-ml/Makefile
@@ -45,26 +45,17 @@ call_build:
 build: pip_build call_build
 
 # run flake8, assuming test requirements already installed
-call_flake8:
+flake8:
 	flake8 --count --statistics
 
-# pip install test requirements and run flake8
-flake8: pip_test call_flake8
-
 # run mypy, assuming test requirements already installed
-call_mypy:
+mypy:
 	mypy --install-types --show-error-codes --non-interactive setup.py
 	mypy --install-types --show-error-codes --non-interactive --package health_ml
 	mypy --install-types --show-error-codes --non-interactive --package testhiml
 
-# pip install test requirements and run mypy
-mypy: pip_test call_mypy
-
-# run basic checks
-call_check: call_flake8 call_mypy
-
-# install test requirements and run basic checks
-check: pip_test call_check
+# run basic checks, assuming test requirements already installed
+check: flake8 mypy
 
 # run pytest on package, assuming test requirements already installed
 call_pytest:
@@ -88,4 +79,4 @@ call_pytest_and_coverage:
 pytest_and_coverage: pip_test call_pytest_and_coverage
 
 # install test requirements and run all tests
-test_all: pip_test call_flake8 call_mypy call_pytest_and_coverage
+test_all: pip_test flake8 mypy call_pytest_and_coverage

--- a/hi-ml/Makefile
+++ b/hi-ml/Makefile
@@ -58,18 +58,12 @@ mypy:
 check: flake8 mypy
 
 # run pytest on package, assuming test requirements already installed
-call_pytest:
+pytest:
 	pytest testhiml
 
-# install test requirements and run tests
-pytest: pip_test call_pytest
-
 # run pytest fast subset on package, assuming test requirements already installed
-call_pytest_fast:
+pytest_fast:
 	pytest -m fast testhiml
-
-# install test requirements and run pytest fast subset
-pytest_fast: pip_test call_pytest_fast
 
 # run pytest with coverage on package
 call_pytest_and_coverage:


### PR DESCRIPTION
The `make check` target presently always runs `pip` to install test dependencies. This is no longer necessary because we are working with a pre-built conda environment. Simplify `make check`, `make pytest` and `make pytest_fast` in a similar fashion.