### PR TITLE
Subsample tiles without replacement

### DIFF
--- a/hi-ml-cpath/src/health_cpath/models/transforms.py
+++ b/hi-ml-cpath/src/health_cpath/models/transforms.py
@@ -221,7 +221,7 @@ class Subsampled(MapTransform, Randomizable):
 
     def randomize(self, total_size: int) -> None:
         subsample_size = min(self.max_size, total_size)
-        self._indices = self.R.choice(total_size, size=subsample_size)
+        self._indices = self.R.choice(total_size, size=subsample_size, replace=False)
 
     def __call__(self, data: Mapping) -> Mapping:
         out_data = dict(data)  # create shallow copy


### PR DESCRIPTION
Current transform `SubSampled` to sample and shuffle the tiles does so with replacement. In this PR, we ensure that tiles are sampled without replacement.