### PR TITLE
MNT: Bump hi-ml-multimodal patch version

### DIFF
--- a/hi-ml-multimodal/.bumpversion.cfg
+++ b/hi-ml-multimodal/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = False
 

--- a/hi-ml-multimodal/.bumpversion.cfg
+++ b/hi-ml-multimodal/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.1.1
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]

--- a/hi-ml-multimodal/.bumpversion.cfg
+++ b/hi-ml-multimodal/.bumpversion.cfg
@@ -4,3 +4,5 @@ commit = True
 tag = False
 
 [bumpversion:file:setup.py]
+
+[bumpversion:file:src/health_multimodal/__init__.py]

--- a/hi-ml-multimodal/.bumpversion.cfg
+++ b/hi-ml-multimodal/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 0.1.1
 commit = True
-tag = True
+tag = False
 
 [bumpversion:file:setup.py]

--- a/hi-ml-multimodal/Makefile
+++ b/hi-ml-multimodal/Makefile
@@ -73,3 +73,13 @@ pyright:
 
 # run basic checks
 check: flake8 mypy pyright
+
+# bump version from specified part (major, minor or patch) (dry run). Usage:
+# $ make bump_version_dry part=patch
+bump_version_dry:
+	bump2version $(part) --verbose --no-tag --dry-run --allow-dirty
+
+# bump version from specified part (major, minor or patch). Usage:
+# $ make bump_version part=patch
+bump_version:
+	bump2version $(part) --verbose --no-tag

--- a/hi-ml-multimodal/Makefile
+++ b/hi-ml-multimodal/Makefile
@@ -77,9 +77,9 @@ check: flake8 mypy pyright
 # bump version from specified part (major, minor or patch) (dry run). Usage:
 # $ make bump_version_dry part=patch
 bump_version_dry:
-	bump2version $(part) --verbose --no-tag --dry-run --allow-dirty
+	bump2version $(part) --verbose --dry-run --allow-dirty
 
 # bump version from specified part (major, minor or patch). Usage:
 # $ make bump_version part=patch
 bump_version:
-	bump2version $(part) --verbose --no-tag
+	bump2version $(part) --verbose

--- a/hi-ml-multimodal/requirements_test.txt
+++ b/hi-ml-multimodal/requirements_test.txt
@@ -1,3 +1,4 @@
+bump2version==1.0.1
 coverage==6.3.2
 flake8==5.0.2
 ipykernel==6.15.0

--- a/hi-ml-multimodal/setup.py
+++ b/hi-ml-multimodal/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_namespace_packages, setup  # type: ignore
 
 
 long_description = Path("README.md").read_text(encoding="utf-8")
-version = "0.1.1"
+version = "0.1.2"
 package_name = "hi-ml-multimodal"
 install_requires = Path("requirements_run.txt").read_text().splitlines()
 

--- a/hi-ml-multimodal/src/health_multimodal/__init__.py
+++ b/hi-ml-multimodal/src/health_multimodal/__init__.py
@@ -3,4 +3,4 @@
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  -------------------------------------------------------------------------------------------
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
Bumping version to include @markpinnock's changes from #724.

Additionally, I've added some convenience tools for semi-automatic bumping with `make`. For example:

```shell
make bump_version part=patch
```

Next, I will run the commands in https://github.com/microsoft/hi-ml/pull/545#issue-1324136707 (which could also become a `make` command) to publish the new version.

TODO:
- [x] Add `__init__` to config file and re-run
- [x] Disable tagging in config