### PR TITLE
ENH: Output the slowest tests

### DIFF
--- a/hi-ml-azure/Makefile
+++ b/hi-ml-azure/Makefile
@@ -67,8 +67,10 @@ pytest_fast:
 	pytest -m fast testazure
 
 # run pytest with coverage on package
+# Output the slowest tests via the --durations flag.
+
 call_pytest_and_coverage:
-	pytest --cov=health_azure  --cov-branch --cov-report=html --cov-report=xml --cov-report=term-missing --cov-config=.coveragerc testazure
+	pytest --durations=50 --cov=health_azure  --cov-branch --cov-report=html --cov-report=xml --cov-report=term-missing --cov-config=.coveragerc testazure
 
 # install test requirements and run pytest coverage
 pytest_and_coverage: pip_test call_pytest_and_coverage

--- a/hi-ml-cpath/Makefile
+++ b/hi-ml-cpath/Makefile
@@ -77,9 +77,10 @@ check: flake8 mypy
 pytest:
 	pytest
 
-# run pytest with coverage on package
+# Run pytest with coverage on package
+# Output the slowest tests via the --durations flag.
 pytest_coverage:
-	pytest --cov=health_cpath --cov SSL --cov-branch --cov-report=html --cov-report=xml --cov-report=term-missing --cov-config=.coveragerc
+	pytest --durations=20 --cov=health_cpath --cov SSL --cov-branch --cov-report=html --cov-report=xml --cov-report=term-missing --cov-config=.coveragerc
 
 # run pytest using GPUs via an AzureML job
 pytest_gpu:

--- a/hi-ml/Makefile
+++ b/hi-ml/Makefile
@@ -66,9 +66,10 @@ pytest:
 pytest_fast:
 	pytest -m fast testhiml
 
-# run pytest with coverage on package
+# Run pytest with coverage on package.
+# Output the slowest tests via the --durations flag.
 call_pytest_and_coverage:
-	pytest --cov=health_ml --cov-branch --cov-report=html --cov-report=xml --cov-report=term-missing --cov-config=.coveragerc testhiml
+	pytest --durations=20 --cov=health_ml --cov-branch --cov-report=html --cov-report=xml --cov-report=term-missing --cov-config=.coveragerc testhiml
 
 # install test requirements and run pytest coverage
 pytest_and_coverage: pip_test call_pytest_and_coverage


### PR DESCRIPTION
For diagnosing slow running tests, add the `--durations` flag to `pytest` to have it print the slowest N tests