### PR TITLE
BUG: ML Client doesn't use workspace config path when specified

### DIFF
--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -238,7 +238,7 @@ class Runner:
             else:
                 hyperparam_args = self.lightning_container.get_hyperparam_args()
                 hyperdrive_config = None
-            ml_client = get_ml_client() if not self.experiment_config.strictly_aml_v1 else None
+            ml_client = get_ml_client(aml_workspace=workspace) if not self.experiment_config.strictly_aml_v1 else None
 
             env_file = choose_conda_env_file(env_file=self.experiment_config.conda_env)
             logging.info(f"Using this Conda environment definition: {env_file}")


### PR DESCRIPTION
in line 210 we get_workspace with the specified workspace_config_path, so we just need to pass it to get_ml_client to prevent it from using the default config path

Any suggestions for testing?

Closes #755 