### PR TITLE
FIX: Set evaluation mode to compute number of dimensions

### DIFF
--- a/hi-ml-multimodal/src/health_multimodal/image/model/model.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/model/model.py
@@ -87,6 +87,7 @@ class ImageModel(nn.Module):
 
         # Initiate encoder, projector, and classifier
         self.encoder = ImageEncoder(img_model_type)
+        self.encoder.eval()  # to get the output size in the next line
         self.feature_size = get_encoder_output_dim(self.encoder)
         self.projector = MLP(input_dim=self.feature_size, output_dim=joint_feature_size,
                              hidden_dim=joint_feature_size, use_1x1_convs=True)

--- a/hi-ml-multimodal/src/health_multimodal/image/model/model.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/model/model.py
@@ -88,7 +88,6 @@ class ImageModel(nn.Module):
 
         # Initiate encoder, projector, and classifier
         self.encoder = ImageEncoder(img_model_type)
-        self.encoder.eval()  # to get the output size in the next line
         self.feature_size = get_encoder_output_dim(self.encoder)
         self.projector = MLP(input_dim=self.feature_size, output_dim=joint_feature_size,
                              hidden_dim=joint_feature_size, use_1x1_convs=True)

--- a/hi-ml-multimodal/src/health_multimodal/image/model/model.py
+++ b/hi-ml-multimodal/src/health_multimodal/image/model/model.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 import enum
 import tempfile
 from pathlib import Path
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple, Union, Sequence
+from typing import Any, Generator, Optional, Tuple, Union, Sequence
 
 import torch
 import torch.nn as nn
@@ -213,5 +214,18 @@ def get_encoder_output_dim(module: torch.nn.Module) -> int:
     x = torch.rand((1, 3, 448, 448)).to(device)
 
     # Extract the number of output feature dimensions
-    representations = module(x)
+    with restore_training_mode(module):
+        module.eval()
+        representations = module(x)
     return representations.shape[1]
+
+
+@contextmanager
+def restore_training_mode(module: nn.Module) -> Generator[None, None, None]:
+    """Restore the training mode of a module after some operation.
+
+    :param module: PyTorch module.
+    """
+    training_mode = module.training
+    yield
+    module.train(mode=training_mode)

--- a/hi-ml-multimodal/test_multimodal/image/model/test_model.py
+++ b/hi-ml-multimodal/test_multimodal/image/model/test_model.py
@@ -12,6 +12,7 @@ from health_multimodal.image.model.model import ImageModel
 from health_multimodal.image.model.model import ImageEncoder
 from health_multimodal.image.model.model import ImageModelOutput
 from health_multimodal.image.model.model import get_biovil_resnet
+from health_multimodal.image.model.model import restore_training_mode
 from health_multimodal.image.model.modules import MultiTaskModel
 from health_multimodal.image.model.resnet import resnet50
 
@@ -156,3 +157,22 @@ def test_hubconf() -> None:
         if value_hub is None and value_himl is None:  # for example, class_logits
             continue
         assert torch.allclose(value_hub, value_himl)
+
+
+def test_restore_training_mode() -> None:
+    model = torch.nn.Conv2d(3, 2, 3)
+    assert model.training
+
+    with restore_training_mode(model):
+        assert model.training
+        model.eval()
+        assert not model.training
+    assert model.training
+
+    model.eval()
+    assert not model.training
+    with restore_training_mode(model):
+        assert not model.training
+        model.train()
+        assert model.training
+    assert not model.training


### PR DESCRIPTION
When guessing the number of output dimensions in the image encoder, the model is in training mode and the batch norm stats get updated. This shouldn't really happen and makes the checks in https://github.com/microsoft/hi-ml/pull/807/files#r1112200449 fail. This PR adds a line to ensure the encode is in `eval` mode before calculating the number of output dims.