### PR TITLE
MNT: Add make command to publish to PyPI

### DIFF
--- a/hi-ml-multimodal/Makefile
+++ b/hi-ml-multimodal/Makefile
@@ -87,14 +87,14 @@ bump_version_dry:
 bump_version:
 	bump2version $(part) --verbose
 
-# publish package to TestPyPI
-publish_test: pip_publish
-	pip install build twine
+# build Python package
+build: pip_publish
 	python -m build
+
+# publish package to TestPyPI
+publish_test: build
 	python -m twine upload --repository testpypi dist/*
 
 # publish package to PyPI
-publish: pip_publish
-	pip install build twine
-	python -m build
+publish: build
 	python -m twine upload dist/*

--- a/hi-ml-multimodal/Makefile
+++ b/hi-ml-multimodal/Makefile
@@ -83,3 +83,9 @@ bump_version_dry:
 # $ make bump_version part=patch
 bump_version:
 	bump2version $(part) --verbose
+
+# publish package to PyPI
+publish:
+	pip install build twine
+	python -m build
+	python -m twine upload dist/*

--- a/hi-ml-multimodal/Makefile
+++ b/hi-ml-multimodal/Makefile
@@ -18,6 +18,9 @@ pip_build: pip_upgrade
 pip_test: pip_upgrade
 	pip install -r requirements_test.txt
 
+pip_publish: pip_upgrade
+	pip install --upgrade build twine
+
 # pip install local package in editable mode for development and testing
 pip_local:
 	pip install -e .
@@ -84,8 +87,14 @@ bump_version_dry:
 bump_version:
 	bump2version $(part) --verbose
 
+# publish package to TestPyPI
+publish_test: pip_publish
+	pip install build twine
+	python -m build
+	python -m twine upload --repository testpypi dist/*
+
 # publish package to PyPI
-publish:
+publish: pip_publish
 	pip install build twine
 	python -m build
 	python -m twine upload dist/*


### PR DESCRIPTION
Running `make publish` from `/hi-ml-multimodal` will publish the package to PyPI. It can be tested before by running `make publish_test`.