### PR TITLE
DOC: Use symlinks to build docs instead of copying files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,9 +145,6 @@ tensorboard_logs/
 docs/source/api
 !docs/source/api/api.rst
 !docs/source/api/multimodal.rst
-# This file is copied from repository root to docs/source by the makefile
-/docs/source/CHANGELOG.md
-/docs/source/CONTRIBUTING.md
 
 node_modules/
 !.github/actions/format_coverage/dist/
@@ -170,6 +167,3 @@ test_outputs/
 lightning_logs/
 # Downloaded datasets
 TCGA-Crck/
-
-# Created while building the docs
-docs/source/multimodal.md

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,7 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	cp ../CHANGELOG.md source/
-	cp ../.github/CONTRIBUTING.md source/
-	cp ../hi-ml-multimodal/README.md source/multimodal.md
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -1,1 +1,1 @@
-../CHANGELOG.md
+../../CHANGELOG.md

--- a/docs/source/CONTRIBUTING.md
+++ b/docs/source/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../.github/CONTRIBUTING.md

--- a/docs/source/CONTRIBUTING.md
+++ b/docs/source/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-../.github/CONTRIBUTING.md
+../../.github/CONTRIBUTING.md

--- a/docs/source/multimodal.md
+++ b/docs/source/multimodal.md
@@ -1,1 +1,1 @@
-../hi-ml-multimodal/README.md
+../../hi-ml-multimodal/README.md

--- a/docs/source/multimodal.md
+++ b/docs/source/multimodal.md
@@ -1,0 +1,1 @@
+../hi-ml-multimodal/README.md


### PR DESCRIPTION
Fixes #823.

There was an issue with the Azure ML Python SDK v2 disliking symlinks in the source dir, but that seems to have been resolved now so this PR removes the copying operation and replaces the targets with symlinks.