### PR TITLE
ENH: Allow variants of model parameters in the same class

### DIFF
--- a/hi-ml/src/health_ml/experiment_config.py
+++ b/hi-ml/src/health_ml/experiment_config.py
@@ -19,8 +19,14 @@ class ExperimentConfig(param.Parameterized):
                                     "that should execute the job. To run on your local machine, omit this argument.")
     num_nodes: int = param.Integer(default=1, doc="The number of virtual machines that will be allocated for this"
                                                   "job in AzureML.")
-    model: str = param.String(doc="The fully qualified name of the model to train/test -e.g."
-                                  "mymodule.configs.MyConfig.")
+    model: str = param.String(
+        doc="The fully or partially qualified name of the model to train/test -e.g. mymodule.configs.MyConfig."
+    )
+    model_variant: str = param.String(
+        default="",
+        doc="The name of the model variant to choose, by calling the 'set_model_variant' method. Model variants "
+        "are selected before applying commandline overrides of parameters"
+    )
     mount_in_azureml: bool = param.Boolean(False,
                                            doc="If False (default), consume datasets in AzureML by downloading at "
                                                "job start. If True, datasets in AzureML are mounted (read on demand "

--- a/hi-ml/src/health_ml/lightning_container.py
+++ b/hi-ml/src/health_ml/lightning_container.py
@@ -265,13 +265,23 @@ class LightningContainer(WorkflowParams,
             logging.warning("Hook `on_run_extra_validation_epoch` is not implemented by lightning module."
                             "The extra validation epoch won't produce any extra outputs.")
 
+    def set_model_variant(self, variant_name: str) -> None:
+        """Choose which variant of the model to use. A variant can for example have a different number of layers
+        compared to the base model. This method is called by the runner to set the variant that should be used, passing
+        in the variant name. A typical implement would set parameters of the object, based on the value of the
+        `variant_name` argument.
+
+        :param variant_name: The name of the model variant that should be set.
+        """
+        pass
+
 
 class LightningModuleWithOptimizer(LightningModule):
     """
     A base class that supplies a method to configure optimizers and LR schedulers. To use this in your model,
     inherit from this class instead of from LightningModule.
     If this class is used, all configuration options for the optimizers and LR schedulers will be also available as
-    commandline arguments (for example, you can supply the InnerEye runner with "--l_rate=1e-2" to change the learning
+    commandline arguments (for example, you can supply the hi-ml runner with "--l_rate=1e-2" to change the learning
     rate.
     """
     # These fields will be set by the LightningContainer when the model is created.

--- a/hi-ml/src/health_ml/runner.py
+++ b/hi-ml/src/health_ml/runner.py
@@ -120,7 +120,10 @@ class Runner:
         # For each parser, feed in the unknown settings from the previous parser. All commandline args should
         # be consumed by name, hence fail if there is something that is still unknown.
         parser2_result = parse_arguments(parser2, args=parser1_result.unknown, fail_on_unknown_args=True)
-        # Apply the overrides and validate. Overrides can come from either YAML settings or the commandline.
+        # Apply the commandline overrides and validate. Any parameters specified on the commandline should have
+        # higher priority than what is done in the model variant
+        assert isinstance(container, LightningContainer)
+        container.set_model_variant(experiment_config.model_variant)
         apply_overrides(container, parser2_result.overrides)  # type: ignore
         container.validate()
 


### PR DESCRIPTION
Based on a commandline flag, models can now switch between different hyperparameters