### PR TITLE
ENH: Refactor Swin Transformer checkpointing

### DIFF
--- a/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
@@ -208,6 +208,9 @@ class BaseMIL(LightningContainer, LoadingParams, EncoderParams, PoolingParams, C
         random see. See `SlidesDataModule` for an example how to achieve that."""
         return None
 
+    def get_encoder_params(self) -> EncoderParams:
+        return create_from_matching_params(self, EncoderParams)
+
     def create_model(self) -> DeepMILModule:
         self.data_module = self.get_data_module()
         outputs_handler = self.get_outputs_handler()
@@ -216,7 +219,7 @@ class BaseMIL(LightningContainer, LoadingParams, EncoderParams, PoolingParams, C
                                        class_names=self.class_names,
                                        class_weights=self.data_module.class_weights,
                                        outputs_folder=self.outputs_folder,
-                                       encoder_params=create_from_matching_params(self, EncoderParams),
+                                       encoder_params=self.get_encoder_params(),
                                        pooling_params=create_from_matching_params(self, PoolingParams),
                                        classifier_params=create_from_matching_params(self, ClassifierParams),
                                        optimizer_params=create_from_matching_params(self, OptimizerParams),

--- a/hi-ml-cpath/src/health_cpath/models/encoders.py
+++ b/hi-ml-cpath/src/health_cpath/models/encoders.py
@@ -339,7 +339,7 @@ class SwinTransformerCheckpointingMixin:
         self.checkpoint_segments_size = checkpoint_segments_size
 
     def custom_patch_embedding_forward(self, images: torch.Tensor) -> torch.Tensor:
-        """Custom patch partchioning checkpoining"""
+        """Custom patch partitioning checkpointing"""
         _, _, H, W = images.shape
         img_size = self.feature_extractor_fn.patch_embed.img_size
         assert H == img_size[0] and W == img_size[1], \

--- a/hi-ml-cpath/src/health_cpath/models/encoders.py
+++ b/hi-ml-cpath/src/health_cpath/models/encoders.py
@@ -340,6 +340,10 @@ class SwinTransformerCheckpointingMixin:
 
     def custom_patch_embedding_forward(self, images: torch.Tensor) -> torch.Tensor:
         """Custom patch partchioning checkpoining"""
+        _, _, H, W = images.shape
+        img_size = self.feature_extractor_fn.patch_embed.img_size
+        assert H == img_size[0] and W == img_size[1], \
+            f"Input image size ({H}*{W}) doesn't match model ({img_size[0]}*{img_size[1]})."
         images = checkpoint(self.feature_extractor_fn.patch_embed.proj, images)
         images = images.flatten(2).transpose(1, 2)  # BCHW -> BNC
         images = checkpoint(self.feature_extractor_fn.patch_embed.norm, images)

--- a/hi-ml-cpath/src/health_cpath/models/encoders.py
+++ b/hi-ml-cpath/src/health_cpath/models/encoders.py
@@ -338,7 +338,7 @@ class SwinTransformerCheckpointingMixin:
         self.feature_extractor_fn = feature_extractor_fn
         self.checkpoint_segments_size = checkpoint_segments_size
 
-    def custom_patch_embedding_forward(self, images: torch.Tensor) -> None:
+    def custom_patch_embedding_forward(self, images: torch.Tensor) -> torch.Tensor:
         """Custom patch partchioning checkpoining"""
         images = checkpoint(self.feature_extractor_fn.patch_embed.proj, images)
         images = images.flatten(2).transpose(1, 2)  # BCHW -> BNC

--- a/hi-ml-cpath/src/health_cpath/utils/deepmil_utils.py
+++ b/hi-ml-cpath/src/health_cpath/utils/deepmil_utils.py
@@ -94,7 +94,6 @@ class EncoderParams(param.Parameterized):
         """Given the current encoder parameters, returns the encoder object.
 
         :param outputs_folder: The output folder where SSL checkpoint should be saved.
-        :param encoder_params: The encoder arguments that define the encoder class object depending on the encoder type.
         :raises ValueError: If the encoder type is not supported.
         :return: A TileEncoder instance for deepmil module.
         """


### PR DESCRIPTION
Refactor Swin Transformer checkpointing to enable patch embedding checkpointing overriding without duplication the whole custom forward