### PR TITLE
ENH: Add account key argument to generate checkpoint URL script 

### DIFF
--- a/hi-ml-cpath/src/health_cpath/scripts/generate_checkpoint_url.py
+++ b/hi-ml-cpath/src/health_cpath/scripts/generate_checkpoint_url.py
@@ -29,6 +29,7 @@ def get_checkpoint_url_from_aml_run(
     """
     workspace = get_workspace(aml_workspace=aml_workspace, workspace_config_path=workspace_config_path)
     account_name = workspace.get_details()['storageAccount'].split('/')[-1]
+    print(f"Workspace {workspace.name} stores its run results in storage account {account_name}.")
     container_name = 'azureml'
     blob_name = f'ExperimentRun/dcid.{run_id}/{DEFAULT_AML_CHECKPOINT_DIR}/{checkpoint_filename}'
     if not sas_token:

--- a/hi-ml-cpath/src/health_cpath/scripts/generate_checkpoint_url.py
+++ b/hi-ml-cpath/src/health_cpath/scripts/generate_checkpoint_url.py
@@ -66,9 +66,8 @@ if __name__ == '__main__':
         help='The number of hours for which the SAS token is valid. Default: 30 for 1 month',
     )
     parser.add_argument(
-        '--acount_key', default='', type=str, help='The Azure Storage account key to use for the SAS token.'
+        '--account_key', default='', type=str, help='The Azure Storage account key to use for the SAS token.'
     )
-
     args = parser.parse_args()
     workspace_config_path = Path(args.workspace_config) if args.workspace_config else None
     url = get_checkpoint_url_from_aml_run(
@@ -76,5 +75,6 @@ if __name__ == '__main__':
         checkpoint_filename=args.checkpoint_filename,
         expiry_days=args.expiry_days,
         workspace_config_path=workspace_config_path,
+        account_key=args.account_key,
     )
     print(f'Checkpoint URL: {url}')

--- a/hi-ml-cpath/src/health_cpath/scripts/generate_checkpoint_url.py
+++ b/hi-ml-cpath/src/health_cpath/scripts/generate_checkpoint_url.py
@@ -33,7 +33,7 @@ def get_checkpoint_url_from_aml_run(
     container_name = 'azureml'
     blob_name = f'ExperimentRun/dcid.{run_id}/{DEFAULT_AML_CHECKPOINT_DIR}/{checkpoint_filename}'
     account_key = datastore.account_key or account_key
-    assert account_key, 'No account key provided.'
+    assert account_key, 'No account key provided. Please provide an account key or SAS token.'
     if not sas_token:
         sas_token = generate_blob_sas(
             account_name=datastore.account_name,

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_deepmil_utils.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_deepmil_utils.py
@@ -42,11 +42,13 @@ def test_load_ssl_checkpoint_from_local_file(tmp_path: Path) -> None:
 
 
 def test_load_ssl_checkpoint_from_url(tmp_path: Path) -> None:
+    aml_workspace = DEFAULT_WORKSPACE.workspace
     blob_url = get_checkpoint_url_from_aml_run(
         run_id=TEST_SSL_RUN_ID,
         checkpoint_filename=LAST_CHECKPOINT_FILE_NAME,
         expiry_days=1,
-        aml_workspace=DEFAULT_WORKSPACE.workspace,
+        aml_workspace=aml_workspace,
+        account_key=aml_workspace.get_default_datastore().account_key,
     )
     encoder_params = EncoderParams(encoder_type=SSLEncoder.__name__, ssl_checkpoint=CheckpointParser(blob_url))
     assert encoder_params.ssl_checkpoint.is_url


### PR DESCRIPTION
Some datastores don't have access to account key, so we need a way of specifying it via commandline 