### PR TITLE
ENH: Clean up design of slides dataset

### DIFF
--- a/hi-ml-cpath/src/health_cpath/configs/classification/DeepSMILEPanda.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/DeepSMILEPanda.py
@@ -8,7 +8,7 @@ from health_cpath.configs.classification.BaseMIL import BaseMIL, BaseMILSlides, 
 from health_cpath.configs.run_ids import innereye_ssl_checkpoint_binary
 from health_cpath.datamodules.panda_module import PandaSlidesDataModule, PandaTilesDataModule
 from health_cpath.datasets.default_paths import PANDA_5X_TILES_DATASET_ID, PANDA_DATASET_ID
-from health_cpath.datasets.panda_dataset import PandaDataset
+from health_cpath.datasets.panda_dataset import PANDA_IMAGE_COLUMN, PandaDataset
 from health_cpath.datasets.panda_tiles_dataset import PandaTilesDataset
 from health_cpath.models.encoders import HistoSSLEncoder, ImageNetSimCLREncoder, Resnet18, SSLEncoder
 from health_cpath.preprocessing.loading import LoadingParams, ROIType, WSIBackend
@@ -153,7 +153,7 @@ class DeepSMILESlidesPanda(BaseMILSlides, BaseDeepSMILEPanda):
             tiling_params=create_from_matching_params(self, TilingParams),
             loading_params=create_from_matching_params(self, LoadingParams),
             seed=self.get_effective_random_seed(),
-            transforms_dict=self.get_transforms_dict(PandaDataset.IMAGE_COLUMN),
+            transforms_dict=self.get_transforms_dict(PANDA_IMAGE_COLUMN),
             crossval_count=self.crossval_count,
             crossval_index=self.crossval_index,
             dataloader_kwargs=self.get_dataloader_kwargs(),

--- a/hi-ml-cpath/src/health_cpath/configs/classification/DeepSMILEPanda.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/DeepSMILEPanda.py
@@ -8,7 +8,7 @@ from health_cpath.configs.classification.BaseMIL import BaseMIL, BaseMILSlides, 
 from health_cpath.configs.run_ids import innereye_ssl_checkpoint_binary
 from health_cpath.datamodules.panda_module import PandaSlidesDataModule, PandaTilesDataModule
 from health_cpath.datasets.default_paths import PANDA_5X_TILES_DATASET_ID, PANDA_DATASET_ID
-from health_cpath.datasets.panda_dataset import PANDA_IMAGE_COLUMN, PandaDataset
+from health_cpath.datasets.panda_dataset import PandaDataset
 from health_cpath.datasets.panda_tiles_dataset import PandaTilesDataset
 from health_cpath.models.encoders import HistoSSLEncoder, ImageNetSimCLREncoder, Resnet18, SSLEncoder
 from health_cpath.preprocessing.loading import LoadingParams, ROIType, WSIBackend
@@ -153,7 +153,7 @@ class DeepSMILESlidesPanda(BaseMILSlides, BaseDeepSMILEPanda):
             tiling_params=create_from_matching_params(self, TilingParams),
             loading_params=create_from_matching_params(self, LoadingParams),
             seed=self.get_effective_random_seed(),
-            transforms_dict=self.get_transforms_dict(PANDA_IMAGE_COLUMN),
+            transforms_dict=self.get_transforms_dict(SlideKey.IMAGE),
             crossval_count=self.crossval_count,
             crossval_index=self.crossval_index,
             dataloader_kwargs=self.get_dataloader_kwargs(),

--- a/hi-ml-cpath/src/health_cpath/configs/classification/DeepSMILESlidesPandaBenchmark.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/DeepSMILESlidesPandaBenchmark.py
@@ -15,7 +15,7 @@ from health_cpath.utils.wsi_utils import TilingParams
 from health_ml.networks.layers.attention_layers import TransformerPooling, TransformerPoolingBenchmark
 from health_ml.utils.checkpoint_utils import CheckpointParser
 from health_ml.deep_learning_config import OptimizerParams
-from health_cpath.datasets.panda_dataset import PandaDataset
+from health_cpath.datasets.panda_dataset import PANDA_IMAGE_COLUMN
 from health_cpath.datamodules.panda_module_benchmark import PandaSlidesDataModuleBenchmark
 from health_cpath.models.encoders import (
     HistoSSLEncoder,
@@ -116,7 +116,7 @@ class DeepSMILESlidesPandaBenchmark(DeepSMILESlidesPanda):
             tiling_params=create_from_matching_params(self, TilingParams),
             loading_params=create_from_matching_params(self, LoadingParams),
             seed=self.get_effective_random_seed(),
-            transforms_dict=self.get_transforms_dict(PandaDataset.IMAGE_COLUMN),
+            transforms_dict=self.get_transforms_dict(PANDA_IMAGE_COLUMN),
             crossval_count=self.crossval_count,
             crossval_index=self.crossval_index,
             dataloader_kwargs=self.get_dataloader_kwargs(),

--- a/hi-ml-cpath/src/health_cpath/configs/classification/DeepSMILESlidesPandaBenchmark.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/DeepSMILESlidesPandaBenchmark.py
@@ -15,7 +15,6 @@ from health_cpath.utils.wsi_utils import TilingParams
 from health_ml.networks.layers.attention_layers import TransformerPooling, TransformerPoolingBenchmark
 from health_ml.utils.checkpoint_utils import CheckpointParser
 from health_ml.deep_learning_config import OptimizerParams
-from health_cpath.datasets.panda_dataset import PANDA_IMAGE_COLUMN
 from health_cpath.datamodules.panda_module_benchmark import PandaSlidesDataModuleBenchmark
 from health_cpath.models.encoders import (
     HistoSSLEncoder,
@@ -116,7 +115,7 @@ class DeepSMILESlidesPandaBenchmark(DeepSMILESlidesPanda):
             tiling_params=create_from_matching_params(self, TilingParams),
             loading_params=create_from_matching_params(self, LoadingParams),
             seed=self.get_effective_random_seed(),
-            transforms_dict=self.get_transforms_dict(PANDA_IMAGE_COLUMN),
+            transforms_dict=self.get_transforms_dict(SlideKey.IMAGE),
             crossval_count=self.crossval_count,
             crossval_index=self.crossval_index,
             dataloader_kwargs=self.get_dataloader_kwargs(),

--- a/hi-ml-cpath/src/health_cpath/datamodules/panda_module.py
+++ b/hi-ml-cpath/src/health_cpath/datamodules/panda_module.py
@@ -50,7 +50,7 @@ class PandaSlidesDataModule(SlidesDataModule):
             proportion_train=0.8,
             proportion_test=0.1,
             proportion_val=0.1,
-            subject_column=dataset.SLIDE_ID_COLUMN,
+            subject_column=dataset.slide_id_column,
         )
 
         if self.crossval_count > 1:

--- a/hi-ml-cpath/src/health_cpath/datamodules/panda_module_benchmark.py
+++ b/hi-ml-cpath/src/health_cpath/datamodules/panda_module_benchmark.py
@@ -28,7 +28,7 @@ class PandaSlidesDataModuleBenchmark(SlidesDataModule):
             proportion_train=0.8,
             proportion_test=0.0,
             proportion_val=0.2,
-            subject_column=dataset.slide_id_col.umn,
+            subject_column=dataset.slide_id_column,
         )
 
         if self.crossval_count > 1:

--- a/hi-ml-cpath/src/health_cpath/datamodules/panda_module_benchmark.py
+++ b/hi-ml-cpath/src/health_cpath/datamodules/panda_module_benchmark.py
@@ -28,7 +28,7 @@ class PandaSlidesDataModuleBenchmark(SlidesDataModule):
             proportion_train=0.8,
             proportion_test=0.0,
             proportion_val=0.2,
-            subject_column=dataset.SLIDE_ID_COLUMN,
+            subject_column=dataset.slide_id_col.umn,
         )
 
         if self.crossval_count > 1:

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -157,11 +157,6 @@ class SlidesDataset(Dataset):
     """Base class for datasets of WSIs, iterating dictionaries of image paths and metadata.
 
     The output dictionaries are indexed by `..utils.naming.SlideKey`.
-
-    :param SLIDE_ID_COLUMN: CSV column name for slide ID.
-    :param IMAGE_COLUMN: CSV column name for relative path to image file.
-    :param SPLIT_COLUMN: CSV column name for train/test split (optional).
-    :param DEFAULT_CSV_FILENAME: Default name of the dataset CSV at the dataset rood directory.
     """
 
     def __init__(

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -150,7 +150,7 @@ class TilesDataset(Dataset):
             self.dataset_df = self.dataset_df.assign(**{TilesDataset.TILE_Y_COLUMN: self.dataset_df[TileKey.TILE_TOP]})
 
 
-SLIDES_DEFAULT_DATASET_CSV = "dataset.csv"
+DEFAULT_DATASET_CSV = "dataset.csv"
 
 
 class SlidesDataset(Dataset):
@@ -174,7 +174,7 @@ class SlidesDataset(Dataset):
         label_column: str = DEFAULT_LABEL_COLUMN,
         n_classes: int = 1,
         dataframe_kwargs: Dict[str, Any] = {},
-        default_csv_filename: str = SLIDES_DEFAULT_DATASET_CSV,
+        default_csv_filename: str = DEFAULT_DATASET_CSV,
         slide_id_column: str = "slide_id",
         image_column: str = "image",
         mask_column: Optional[str] = None,

--- a/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/base_dataset.py
@@ -150,6 +150,9 @@ class TilesDataset(Dataset):
             self.dataset_df = self.dataset_df.assign(**{TilesDataset.TILE_Y_COLUMN: self.dataset_df[TileKey.TILE_TOP]})
 
 
+SLIDES_DEFAULT_DATASET_CSV = "dataset.csv"
+
+
 class SlidesDataset(Dataset):
     """Base class for datasets of WSIs, iterating dictionaries of image paths and metadata.
 
@@ -161,8 +164,6 @@ class SlidesDataset(Dataset):
     :param DEFAULT_CSV_FILENAME: Default name of the dataset CSV at the dataset rood directory.
     """
 
-    DEFAULT_CSV_FILENAME: str = "dataset.csv"
-
     def __init__(
         self,
         root: Union[str, Path],
@@ -173,6 +174,7 @@ class SlidesDataset(Dataset):
         label_column: str = DEFAULT_LABEL_COLUMN,
         n_classes: int = 1,
         dataframe_kwargs: Dict[str, Any] = {},
+        default_csv_filename: str = SLIDES_DEFAULT_DATASET_CSV,
         slide_id_column: str = "slide_id",
         image_column: str = "image",
         mask_column: Optional[str] = None,
@@ -198,6 +200,7 @@ class SlidesDataset(Dataset):
         :param image_column: CSV column name for relative path to image file. Default is `image`.
         :param mask_column: CSV column name for relative path to mask file. Default is `None`.
         :param split_column: CSV column name for train/test split. Default is `None`.
+        :param default_csv_filename: Default name of the dataset CSV at the dataset root directory.
         """
         self.root_dir = Path(root)
         self.label_column = label_column
@@ -208,13 +211,14 @@ class SlidesDataset(Dataset):
         self.mask_column = mask_column
         self.split_column = split_column
         self.metadata_columns = metadata_columns
+        self.default_csv_filename = default_csv_filename
         if self.split_column is None and train is not None:
             raise ValueError("Train/test split was specified but dataset has no split column")
 
         if dataset_df is not None:
             self.dataset_csv = None
         else:
-            self.dataset_csv = dataset_csv or self.root_dir / self.DEFAULT_CSV_FILENAME
+            self.dataset_csv = dataset_csv or self.root_dir / self.default_csv_filename
             dataset_df = pd.read_csv(self.dataset_csv, **self.dataframe_kwargs)
 
         if dataset_df.index.name != self.slide_id_column:

--- a/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
@@ -7,10 +7,14 @@ from pathlib import Path
 from typing import Any, Dict, Union, Optional
 from health_cpath.datasets.base_dataset import SlidesDataset
 
-PANDA_SLIDE_ID_COLUMN = 'image_id'
-PANDA_IMAGE_COLUMN = 'image'
-PANDA_MASK_COLUMN = 'mask'
-PANDA_METADATA_COLUMNS = ('data_provider', 'isup_grade', 'gleason_score')
+
+class PandaColumns:
+    SLIDE_ID = 'image_id'
+    IMAGE = 'image'
+    MASK = 'mask'
+    METADATA = ('data_provider', 'isup_grade', 'gleason_score')
+
+
 PANDA_CSV_FILENAME = "train.csv"
 
 
@@ -40,10 +44,10 @@ class PandaDataset(SlidesDataset):
             label_column=label_column,
             n_classes=n_classes,
             dataframe_kwargs=dataframe_kwargs,
-            slide_id_column=PANDA_SLIDE_ID_COLUMN,
-            image_column=PANDA_IMAGE_COLUMN,
-            mask_column=PANDA_MASK_COLUMN,
-            metadata_columns=PANDA_METADATA_COLUMNS,
+            slide_id_column=PandaColumns.SLIDE_ID,
+            image_column=PandaColumns.IMAGE,
+            mask_column=PandaColumns.MASK,
+            metadata_columns=PandaColumns.METADATA,
             default_csv_filename=PANDA_CSV_FILENAME,
         )
         # PANDA CSV does not come with paths for image and mask files

--- a/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
@@ -44,6 +44,7 @@ class PandaDataset(SlidesDataset):
             image_column=PANDA_IMAGE_COLUMN,
             mask_column=PANDA_MASK_COLUMN,
             metadata_columns=PANDA_METADATA_COLUMNS,
+            default_csv_filename=PANDA_CSV_FILENAME,
         )
         # PANDA CSV does not come with paths for image and mask files
         slide_ids = self.dataset_df.index

--- a/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/panda_dataset.py
@@ -7,6 +7,12 @@ from pathlib import Path
 from typing import Any, Dict, Union, Optional
 from health_cpath.datasets.base_dataset import SlidesDataset
 
+PANDA_SLIDE_ID_COLUMN = 'image_id'
+PANDA_IMAGE_COLUMN = 'image'
+PANDA_MASK_COLUMN = 'mask'
+PANDA_METADATA_COLUMNS = ('data_provider', 'isup_grade', 'gleason_score')
+PANDA_CSV_FILENAME = "train.csv"
+
 
 class PandaDataset(SlidesDataset):
     """Dataset class for loading files from the PANDA challenge dataset.
@@ -16,14 +22,6 @@ class PandaDataset(SlidesDataset):
 
     Ref.: https://www.kaggle.com/c/prostate-cancer-grade-assessment/overview
     """
-
-    SLIDE_ID_COLUMN = 'image_id'
-    IMAGE_COLUMN = 'image'
-    MASK_COLUMN = 'mask'
-
-    METADATA_COLUMNS = ('data_provider', 'isup_grade', 'gleason_score')
-
-    DEFAULT_CSV_FILENAME = "train.csv"
 
     def __init__(
         self,
@@ -42,9 +40,13 @@ class PandaDataset(SlidesDataset):
             label_column=label_column,
             n_classes=n_classes,
             dataframe_kwargs=dataframe_kwargs,
+            slide_id_column=PANDA_SLIDE_ID_COLUMN,
+            image_column=PANDA_IMAGE_COLUMN,
+            mask_column=PANDA_MASK_COLUMN,
+            metadata_columns=PANDA_METADATA_COLUMNS,
         )
         # PANDA CSV does not come with paths for image and mask files
         slide_ids = self.dataset_df.index
-        self.dataset_df[self.IMAGE_COLUMN] = "train_images/" + slide_ids + ".tiff"
-        self.dataset_df[self.MASK_COLUMN] = "train_label_masks/" + slide_ids + "_mask.tiff"
+        self.dataset_df[self.image_column] = "train_images/" + slide_ids + ".tiff"
+        self.dataset_df[self.mask_column] = "train_label_masks/" + slide_ids + "_mask.tiff"
         self.validate_columns()

--- a/hi-ml-cpath/src/health_cpath/datasets/tcga_prad_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/tcga_prad_dataset.py
@@ -11,6 +11,9 @@ import pandas as pd
 from health_cpath.datasets.base_dataset import DEFAULT_LABEL_COLUMN, SlidesDataset
 
 
+TCGA_PRAD_DATASET_FILE = "dataset.csv"
+
+
 class TcgaPradDataset(SlidesDataset):
     """Dataset class for loading TCGA-PRAD slides.
 
@@ -41,6 +44,7 @@ class TcgaPradDataset(SlidesDataset):
             dataset_df,
             validate_columns=False,
             label_column=label_column,
+            default_csv_filename=TCGA_PRAD_DATASET_FILE,
             image_column="image_path",
         )
         # Example of how to define a custom label column from existing columns:

--- a/hi-ml-cpath/src/health_cpath/datasets/tcga_prad_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/tcga_prad_dataset.py
@@ -14,6 +14,14 @@ from health_cpath.datasets.base_dataset import DEFAULT_LABEL_COLUMN, SlidesDatas
 TCGA_PRAD_DATASET_FILE = "dataset.csv"
 
 
+class TcgaColumns:
+    """Column names for TCGA dataset CSV files."""
+
+    IMAGE = "image_path"
+    LABEL1 = "label1"
+    LABEL2 = "label2"
+
+
 class TcgaPradDataset(SlidesDataset):
     """Dataset class for loading TCGA-PRAD slides.
 
@@ -45,10 +53,12 @@ class TcgaPradDataset(SlidesDataset):
             validate_columns=False,
             label_column=label_column,
             default_csv_filename=TCGA_PRAD_DATASET_FILE,
-            image_column="image_path",
+            image_column=TcgaColumns.IMAGE,
         )
         # Example of how to define a custom label column from existing columns:
-        self.dataset_df[self.label_column] = (self.dataset_df['label1'] | self.dataset_df['label2']).astype(
+        self.dataset_df[self.label_column] = (
+            self.dataset_df[TcgaColumns.LABEL1] | self.dataset_df[TcgaColumns.LABEL2]
+        ).astype(
             int
         )  # noqa: W503
         self.validate_columns()

--- a/hi-ml-cpath/src/health_cpath/datasets/tcga_prad_dataset.py
+++ b/hi-ml-cpath/src/health_cpath/datasets/tcga_prad_dataset.py
@@ -21,10 +21,6 @@ class TcgaPradDataset(SlidesDataset):
     - `'label'` (int, 0 or 1): label for predicting positive or negative
     """
 
-    IMAGE_COLUMN: str = 'image_path'
-
-    DEFAULT_CSV_FILENAME: str = "dataset.csv"
-
     def __init__(
         self,
         root: Union[str, Path],
@@ -39,7 +35,14 @@ class TcgaPradDataset(SlidesDataset):
         :param dataset_df: A potentially pre-processed dataframe in the same format as would be read
         from the dataset CSV file, e.g. after some filtering. If given, overrides `dataset_csv`.
         """
-        super().__init__(root, dataset_csv, dataset_df, validate_columns=False, label_column=label_column)
+        super().__init__(
+            root,
+            dataset_csv,
+            dataset_df,
+            validate_columns=False,
+            label_column=label_column,
+            image_column="image_path",
+        )
         # Example of how to define a custom label column from existing columns:
         self.dataset_df[self.label_column] = (self.dataset_df['label1'] | self.dataset_df['label2']).astype(
             int

--- a/hi-ml-cpath/src/health_cpath/scripts/tcga_dataset_prep.py
+++ b/hi-ml-cpath/src/health_cpath/scripts/tcga_dataset_prep.py
@@ -8,7 +8,7 @@ import pandas as pd
 from health_cpath.datasets.default_paths import TCGA_CRCK_DATASET_ID
 
 from health_cpath.utils.tcga_utils import extract_fields
-from health_cpath.datasets.tcga_prad_dataset import TCGA_PRAD_DATASET_FILE, TcgaPradDataset
+from health_cpath.datasets.tcga_prad_dataset import TCGA_PRAD_DATASET_FILE
 
 
 def check_dataset_csv_paths(dataset_dir: Path) -> None:

--- a/hi-ml-cpath/src/health_cpath/scripts/tcga_dataset_prep.py
+++ b/hi-ml-cpath/src/health_cpath/scripts/tcga_dataset_prep.py
@@ -8,11 +8,11 @@ import pandas as pd
 from health_cpath.datasets.default_paths import TCGA_CRCK_DATASET_ID
 
 from health_cpath.utils.tcga_utils import extract_fields
-from health_cpath.datasets.tcga_prad_dataset import TcgaPradDataset
+from health_cpath.datasets.tcga_prad_dataset import TCGA_PRAD_DATASET_FILE, TcgaPradDataset
 
 
 def check_dataset_csv_paths(dataset_dir: Path) -> None:
-    df = pd.read_csv(dataset_dir / TcgaPradDataset.DEFAULT_CSV_FILENAME)
+    df = pd.read_csv(dataset_dir / TCGA_PRAD_DATASET_FILE)
     for img_path in df.image:
         assert (dataset_dir / img_path).is_file()
 
@@ -38,6 +38,6 @@ if __name__ == '__main__':
 
     # takes up to ~20 seconds
     df = df.apply(extract_fields, axis='columns', result_type='expand')
-    df.to_csv(dataset_dir / TcgaPradDataset.DEFAULT_CSV_FILENAME, index=False)
+    df.to_csv(dataset_dir / TCGA_PRAD_DATASET_FILE, index=False)
 
     check_dataset_csv_paths(dataset_dir)

--- a/hi-ml-cpath/src/health_cpath/utils/montage.py
+++ b/hi-ml-cpath/src/health_cpath/utils/montage.py
@@ -24,7 +24,7 @@ from health_azure.argparsing import apply_overrides, parse_arguments
 from health_cpath.preprocessing.loading import WSIBackend
 from health_cpath.utils.montage_config import MontageConfig, create_montage_argparser
 from health_cpath.utils.naming import SlideKey
-from health_cpath.datasets.base_dataset import SlidesDataset
+from health_cpath.datasets.base_dataset import SLIDES_DEFAULT_DATASET_CSV, SlidesDataset
 from health_ml.utils.type_annotations import TupleInt3
 
 
@@ -425,13 +425,13 @@ class MontageCreation(MontageConfig):
                 dataset = SlidesDataset(root=input_folder)
             except Exception as ex:
                 logging.error("Unable to load dataset.")
-                file = input_folder / SlidesDataset.DEFAULT_CSV_FILENAME
+                file = input_folder / SLIDES_DEFAULT_DATASET_CSV
                 # Print the whole directory tree to check where the problem is.
                 while str(file) != str(file.root):
                     logging.debug(f"File: {file}, exists: {file.exists()}")
                     file = file.parent
                 raise ValueError(
-                    f"Unable to load dataset. Check if the file {SlidesDataset.DEFAULT_CSV_FILENAME} "
+                    f"Unable to load dataset. Check if the file {SLIDES_DEFAULT_DATASET_CSV} "
                     f"exists, or provide a file name pattern via --image_glob_pattern. Error: {ex}"
                 )
             return dataset

--- a/hi-ml-cpath/src/health_cpath/utils/montage.py
+++ b/hi-ml-cpath/src/health_cpath/utils/montage.py
@@ -24,7 +24,7 @@ from health_azure.argparsing import apply_overrides, parse_arguments
 from health_cpath.preprocessing.loading import WSIBackend
 from health_cpath.utils.montage_config import MontageConfig, create_montage_argparser
 from health_cpath.utils.naming import SlideKey
-from health_cpath.datasets.base_dataset import SLIDES_DEFAULT_DATASET_CSV, SlidesDataset
+from health_cpath.datasets.base_dataset import DEFAULT_DATASET_CSV, SlidesDataset
 from health_ml.utils.type_annotations import TupleInt3
 
 
@@ -425,13 +425,13 @@ class MontageCreation(MontageConfig):
                 dataset = SlidesDataset(root=input_folder)
             except Exception as ex:
                 logging.error("Unable to load dataset.")
-                file = input_folder / SLIDES_DEFAULT_DATASET_CSV
+                file = input_folder / DEFAULT_DATASET_CSV
                 # Print the whole directory tree to check where the problem is.
                 while str(file) != str(file.root):
                     logging.debug(f"File: {file}, exists: {file.exists()}")
                     file = file.parent
                 raise ValueError(
-                    f"Unable to load dataset. Check if the file {SLIDES_DEFAULT_DATASET_CSV} "
+                    f"Unable to load dataset. Check if the file {DEFAULT_DATASET_CSV} "
                     f"exists, or provide a file name pattern via --image_glob_pattern. Error: {ex}"
                 )
             return dataset

--- a/hi-ml-cpath/src/health_cpath/utils/montage.py
+++ b/hi-ml-cpath/src/health_cpath/utils/montage.py
@@ -476,7 +476,7 @@ class MontageCreation(MontageConfig):
         :param exclude_items: If True, exclude the list in `items` from the montage. If False, include
             only those in the montage.
         :param restrict_by_column: The column name that should be used for inclusion/exclusion lists
-            (default=dataset.SLIDE_ID_COLUMN).
+            (default=dataset.slide_id_column).
         :return: A path to the created montage, or None if no images were available for creating the montage.
         """
         if isinstance(dataset, pd.DataFrame):
@@ -489,7 +489,7 @@ class MontageCreation(MontageConfig):
             if isinstance(dataset, pd.DataFrame):
                 restrict_by_column = SlideKey.SLIDE_ID.value
             else:
-                restrict_by_column = dataset.SLIDE_ID_COLUMN
+                restrict_by_column = dataset.slide_id_column
         if items:
             if exclude_items:
                 logging.info(f"Using dataset column '{restrict_by_column}' to exclude slides")

--- a/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
+++ b/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
@@ -100,7 +100,13 @@ class TiffConversionConfig(param.Parameterized):
             .str.replace(AMPERSAND, self.replace_ampersand_by)
             .map(lambda x: str(Path(x).with_suffix(TIFF_EXTENSION)))
         )
-        new_dataset_path = output_folder / (self.converted_dataset_csv or self.slides_dataset.dataset_csv.name)
+        if self.converted_dataset_csv:
+            new_dataset_file = self.converted_dataset_csv
+        elif self.slides_dataset.dataset_csv is not None:
+            new_dataset_file = Path(self.slides_dataset.dataset_csv).name
+        else:
+            raise ValueError("Unable to determine the output filename. Please provide in 'converted_dataset_csv'")
+        new_dataset_path = output_folder / new_dataset_file
         new_dataset_df.to_csv(new_dataset_path, sep="\t" if new_dataset_path.suffix == ".tsv" else ",")
         logging.info(f"Saved new dataset tsv file to {new_dataset_path}")
 

--- a/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
+++ b/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
@@ -100,7 +100,7 @@ class TiffConversionConfig(param.Parameterized):
             .str.replace(AMPERSAND, self.replace_ampersand_by)
             .map(lambda x: str(Path(x).with_suffix(TIFF_EXTENSION)))
         )
-        new_dataset_path = output_folder / (self.converted_dataset_csv or self.slides_dataset.default_csv_filename)
+        new_dataset_path = output_folder / (self.converted_dataset_csv or self.slides_dataset.dataset_csv.name)
         new_dataset_df.to_csv(new_dataset_path, sep="\t" if new_dataset_path.suffix == ".tsv" else ",")
         logging.info(f"Saved new dataset tsv file to {new_dataset_path}")
 

--- a/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
+++ b/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
@@ -100,7 +100,7 @@ class TiffConversionConfig(param.Parameterized):
             .str.replace(AMPERSAND, self.replace_ampersand_by)
             .map(lambda x: str(Path(x).with_suffix(TIFF_EXTENSION)))
         )
-        new_dataset_path = output_folder / (self.converted_dataset_csv or self.slides_dataset.DEFAULT_CSV_FILENAME)
+        new_dataset_path = output_folder / (self.converted_dataset_csv or self.slides_dataset.default_csv_filename)
         new_dataset_df.to_csv(new_dataset_path, sep="\t" if new_dataset_path.suffix == ".tsv" else ",")
         logging.info(f"Saved new dataset tsv file to {new_dataset_path}")
 

--- a/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
+++ b/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
@@ -95,8 +95,8 @@ class TiffConversionConfig(param.Parameterized):
         :param output_folder: The folder where the new dataset csv file will be saved.
         """
         new_dataset_df = deepcopy(self.slides_dataset.dataset_df)
-        new_dataset_df[self.slides_dataset.IMAGE_COLUMN] = (
-            new_dataset_df[self.slides_dataset.IMAGE_COLUMN]
+        new_dataset_df[self.slides_dataset.image_column] = (
+            new_dataset_df[self.slides_dataset.image_column]
             .str.replace(AMPERSAND, self.replace_ampersand_by)
             .map(lambda x: str(Path(x).with_suffix(TIFF_EXTENSION)))
         )

--- a/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
+++ b/hi-ml-cpath/src/health_cpath/utils/tiff_conversion_config.py
@@ -100,12 +100,9 @@ class TiffConversionConfig(param.Parameterized):
             .str.replace(AMPERSAND, self.replace_ampersand_by)
             .map(lambda x: str(Path(x).with_suffix(TIFF_EXTENSION)))
         )
-        if self.converted_dataset_csv:
-            new_dataset_file = self.converted_dataset_csv
-        elif self.slides_dataset.dataset_csv is not None:
-            new_dataset_file = Path(self.slides_dataset.dataset_csv).name
-        else:
-            raise ValueError("Unable to determine the output filename. Please provide in 'converted_dataset_csv'")
+        new_dataset_file = (
+            self.converted_dataset_csv if self.converted_dataset_csv else self.slides_dataset.default_csv_filename
+        )
         new_dataset_path = output_folder / new_dataset_file
         new_dataset_df.to_csv(new_dataset_path, sep="\t" if new_dataset_path.suffix == ".tsv" else ",")
         logging.info(f"Saved new dataset tsv file to {new_dataset_path}")

--- a/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_slides.py
+++ b/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_slides.py
@@ -14,12 +14,7 @@ import torch
 from pytorch_lightning import seed_everything
 
 from health_cpath.configs.classification.DeepSMILESlidesPandaBenchmark import DeepSMILESlidesPandaBenchmark
-from health_cpath.datasets.panda_dataset import (
-    PANDA_MASK_COLUMN,
-    PANDA_METADATA_COLUMNS,
-    PANDA_SLIDE_ID_COLUMN,
-    PandaDataset,
-)
+from health_cpath.datasets.panda_dataset import PandaColumns, PandaDataset
 from health_cpath.preprocessing.loading import ROIType, WSIBackend
 from health_cpath.utils.naming import SlideKey
 from testhisto.mocks.base_data_generator import MockHistoDataType
@@ -117,7 +112,7 @@ def test_validate_columns(tmp_path: Path) -> None:
         background_val=255,
         tiles_pos_type=TilesPositioningType.RANDOM,
     )
-    usecols = [PANDA_SLIDE_ID_COLUMN, PANDA_MASK_COLUMN]
+    usecols = [PandaColumns.SLIDE_ID, PandaColumns.MASK]
     with pytest.raises(ValueError, match=r"Expected columns"):
         _ = PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols})
-    _ = PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols + [PANDA_METADATA_COLUMNS[1]]})
+    _ = PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols + [PandaColumns.METADATA[1]]})

--- a/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_slides.py
+++ b/hi-ml-cpath/testhisto/testhisto/datasets/test_panda_slides.py
@@ -14,7 +14,12 @@ import torch
 from pytorch_lightning import seed_everything
 
 from health_cpath.configs.classification.DeepSMILESlidesPandaBenchmark import DeepSMILESlidesPandaBenchmark
-from health_cpath.datasets.panda_dataset import PandaDataset
+from health_cpath.datasets.panda_dataset import (
+    PANDA_MASK_COLUMN,
+    PANDA_METADATA_COLUMNS,
+    PANDA_SLIDE_ID_COLUMN,
+    PandaDataset,
+)
 from health_cpath.preprocessing.loading import ROIType, WSIBackend
 from health_cpath.utils.naming import SlideKey
 from testhisto.mocks.base_data_generator import MockHistoDataType
@@ -112,7 +117,7 @@ def test_validate_columns(tmp_path: Path) -> None:
         background_val=255,
         tiles_pos_type=TilesPositioningType.RANDOM,
     )
-    usecols = [PandaDataset.SLIDE_ID_COLUMN, PandaDataset.MASK_COLUMN]
+    usecols = [PANDA_SLIDE_ID_COLUMN, PANDA_MASK_COLUMN]
     with pytest.raises(ValueError, match=r"Expected columns"):
         _ = PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols})
-    _ = PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols + [PandaDataset.METADATA_COLUMNS[1]]})
+    _ = PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols + [PANDA_METADATA_COLUMNS[1]]})

--- a/hi-ml-cpath/testhisto/testhisto/mocks/slides_generator.py
+++ b/hi-ml-cpath/testhisto/testhisto/mocks/slides_generator.py
@@ -11,7 +11,12 @@ import pandas as pd
 import torch
 from tifffile.tifffile import TiffWriter, PHOTOMETRIC, COMPRESSION
 from torch import Tensor
-from health_cpath.datasets.panda_dataset import PandaDataset
+from health_cpath.datasets.panda_dataset import (
+    PANDA_CSV_FILENAME,
+    PANDA_MASK_COLUMN,
+    PANDA_METADATA_COLUMNS,
+    PANDA_SLIDE_ID_COLUMN,
+)
 from health_cpath.preprocessing.tiff_conversion import ResolutionUnit
 from testhisto.mocks.base_data_generator import MockHistoDataGenerator, MockHistoDataType, PANDA_N_CLASSES
 
@@ -87,17 +92,15 @@ class MockPandaSlidesGenerator(MockHistoDataGenerator):
             list(self.ISUP_GRADE_MAPPING.keys()),
             self.n_slides // PANDA_N_CLASSES + 1,
         )
-        mock_metadata: dict = {
-            col: [] for col in [PandaDataset.SLIDE_ID_COLUMN, PandaDataset.MASK_COLUMN, *PandaDataset.METADATA_COLUMNS]
-        }
+        mock_metadata: dict = {col: [] for col in [PANDA_SLIDE_ID_COLUMN, PANDA_MASK_COLUMN, *PANDA_METADATA_COLUMNS]}
         for slide_id in range(self.n_slides):
-            mock_metadata[PandaDataset.SLIDE_ID_COLUMN].append(f"_{slide_id}")
-            mock_metadata[PandaDataset.MASK_COLUMN].append(f"_{slide_id}_mask")
+            mock_metadata[PANDA_SLIDE_ID_COLUMN].append(f"_{slide_id}")
+            mock_metadata[PANDA_MASK_COLUMN].append(f"_{slide_id}_mask")
             mock_metadata[self.DATA_PROVIDER].append(np.random.choice(self.DATA_PROVIDERS_VALUES))
             mock_metadata[self.ISUP_GRADE].append(isup_grades[slide_id])
             mock_metadata[self.GLEASON_SCORE].append(np.random.choice(self.ISUP_GRADE_MAPPING[isup_grades[slide_id]]))
         df = pd.DataFrame(data=mock_metadata)
-        csv_filename = self.dest_data_path / PandaDataset.DEFAULT_CSV_FILENAME
+        csv_filename = self.dest_data_path / PANDA_CSV_FILENAME
         df.to_csv(csv_filename, index=False)
 
     def create_mock_wsi(self, tiles: Tensor) -> Tuple[np.ndarray, Optional[np.ndarray]]:

--- a/hi-ml-cpath/testhisto/testhisto/mocks/slides_generator.py
+++ b/hi-ml-cpath/testhisto/testhisto/mocks/slides_generator.py
@@ -11,12 +11,7 @@ import pandas as pd
 import torch
 from tifffile.tifffile import TiffWriter, PHOTOMETRIC, COMPRESSION
 from torch import Tensor
-from health_cpath.datasets.panda_dataset import (
-    PANDA_CSV_FILENAME,
-    PANDA_MASK_COLUMN,
-    PANDA_METADATA_COLUMNS,
-    PANDA_SLIDE_ID_COLUMN,
-)
+from health_cpath.datasets.panda_dataset import PandaColumns, PANDA_CSV_FILENAME
 from health_cpath.preprocessing.tiff_conversion import ResolutionUnit
 from testhisto.mocks.base_data_generator import MockHistoDataGenerator, MockHistoDataType, PANDA_N_CLASSES
 
@@ -92,10 +87,10 @@ class MockPandaSlidesGenerator(MockHistoDataGenerator):
             list(self.ISUP_GRADE_MAPPING.keys()),
             self.n_slides // PANDA_N_CLASSES + 1,
         )
-        mock_metadata: dict = {col: [] for col in [PANDA_SLIDE_ID_COLUMN, PANDA_MASK_COLUMN, *PANDA_METADATA_COLUMNS]}
+        mock_metadata: dict = {col: [] for col in [PandaColumns.SLIDE_ID, PandaColumns.MASK, *PandaColumns.METADATA]}
         for slide_id in range(self.n_slides):
-            mock_metadata[PANDA_SLIDE_ID_COLUMN].append(f"_{slide_id}")
-            mock_metadata[PANDA_MASK_COLUMN].append(f"_{slide_id}_mask")
+            mock_metadata[PandaColumns.SLIDE_ID].append(f"_{slide_id}")
+            mock_metadata[PandaColumns.MASK].append(f"_{slide_id}_mask")
             mock_metadata[self.DATA_PROVIDER].append(np.random.choice(self.DATA_PROVIDERS_VALUES))
             mock_metadata[self.ISUP_GRADE].append(isup_grades[slide_id])
             mock_metadata[self.GLEASON_SCORE].append(np.random.choice(self.ISUP_GRADE_MAPPING[isup_grades[slide_id]]))

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_montage.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_montage.py
@@ -17,7 +17,7 @@ from health_cpath.utils.montage import (
     make_montage_from_dir,
     restrict_dataset,
 )
-from health_cpath.datasets.base_dataset import SLIDES_DEFAULT_DATASET_CSV, SlidesDataset
+from health_cpath.datasets.base_dataset import DEFAULT_DATASET_CSV, SlidesDataset
 from health_cpath.datasets.panda_dataset import (
     PANDA_MASK_COLUMN,
     PANDA_METADATA_COLUMNS,
@@ -91,7 +91,7 @@ def temp_slides_dataset(tmp_path_factory: pytest.TempPathFactory) -> Generator:
         SlideKey.LABEL: [f"Label {i}" for i in range(NUM_SLIDES)],
     }
     df = pd.DataFrame(data=metadata)
-    csv_filename = tmp_path / SLIDES_DEFAULT_DATASET_CSV
+    csv_filename = tmp_path / DEFAULT_DATASET_CSV
     df.to_csv(csv_filename, index=False)
     # Tests fail non-deterministically, saying that the dataset file does not exist (yet). Hence, wait.
     wait_until_file_exists(csv_filename)

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_montage.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_montage.py
@@ -18,7 +18,12 @@ from health_cpath.utils.montage import (
     restrict_dataset,
 )
 from health_cpath.datasets.base_dataset import SlidesDataset
-from health_cpath.datasets.panda_dataset import PandaDataset
+from health_cpath.datasets.panda_dataset import (
+    PANDA_MASK_COLUMN,
+    PANDA_METADATA_COLUMNS,
+    PANDA_SLIDE_ID_COLUMN,
+    PandaDataset,
+)
 from health_cpath.scripts.create_montage import main as script_main
 from health_cpath.utils.naming import SlideKey
 from testhisto.mocks.base_data_generator import MockHistoDataType
@@ -62,8 +67,8 @@ def temp_panda_dataset(tmp_path_factory: pytest.TempPathFactory) -> Generator:
     """A fixture that creates a PandaDataset object with randomly created slides."""
     tmp_path = tmp_path_factory.mktemp("mock_panda")
     _create_slides_images(tmp_path)
-    usecols = [PandaDataset.SLIDE_ID_COLUMN, PandaDataset.MASK_COLUMN]
-    yield PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols + list(PandaDataset.METADATA_COLUMNS)})
+    usecols = [PANDA_SLIDE_ID_COLUMN, PANDA_MASK_COLUMN]
+    yield PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols + list(PANDA_METADATA_COLUMNS)})
 
 
 @pytest.fixture(scope="module")

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_montage.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_montage.py
@@ -17,7 +17,7 @@ from health_cpath.utils.montage import (
     make_montage_from_dir,
     restrict_dataset,
 )
-from health_cpath.datasets.base_dataset import SlidesDataset
+from health_cpath.datasets.base_dataset import SLIDES_DEFAULT_DATASET_CSV, SlidesDataset
 from health_cpath.datasets.panda_dataset import (
     PANDA_MASK_COLUMN,
     PANDA_METADATA_COLUMNS,
@@ -91,7 +91,7 @@ def temp_slides_dataset(tmp_path_factory: pytest.TempPathFactory) -> Generator:
         SlideKey.LABEL: [f"Label {i}" for i in range(NUM_SLIDES)],
     }
     df = pd.DataFrame(data=metadata)
-    csv_filename = tmp_path / SlidesDataset.DEFAULT_CSV_FILENAME
+    csv_filename = tmp_path / SLIDES_DEFAULT_DATASET_CSV
     df.to_csv(csv_filename, index=False)
     # Tests fail non-deterministically, saying that the dataset file does not exist (yet). Hence, wait.
     wait_until_file_exists(csv_filename)

--- a/hi-ml-cpath/testhisto/testhisto/utils/test_montage.py
+++ b/hi-ml-cpath/testhisto/testhisto/utils/test_montage.py
@@ -18,12 +18,7 @@ from health_cpath.utils.montage import (
     restrict_dataset,
 )
 from health_cpath.datasets.base_dataset import DEFAULT_DATASET_CSV, SlidesDataset
-from health_cpath.datasets.panda_dataset import (
-    PANDA_MASK_COLUMN,
-    PANDA_METADATA_COLUMNS,
-    PANDA_SLIDE_ID_COLUMN,
-    PandaDataset,
-)
+from health_cpath.datasets.panda_dataset import PandaColumns, PandaDataset
 from health_cpath.scripts.create_montage import main as script_main
 from health_cpath.utils.naming import SlideKey
 from testhisto.mocks.base_data_generator import MockHistoDataType
@@ -67,8 +62,8 @@ def temp_panda_dataset(tmp_path_factory: pytest.TempPathFactory) -> Generator:
     """A fixture that creates a PandaDataset object with randomly created slides."""
     tmp_path = tmp_path_factory.mktemp("mock_panda")
     _create_slides_images(tmp_path)
-    usecols = [PANDA_SLIDE_ID_COLUMN, PANDA_MASK_COLUMN]
-    yield PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols + list(PANDA_METADATA_COLUMNS)})
+    usecols = [PandaColumns.SLIDE_ID, PandaColumns.MASK]
+    yield PandaDataset(root=tmp_path, dataframe_kwargs={"usecols": usecols + list(PandaColumns.METADATA)})
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Metadata columns are presently set via class variables, rather than in the constructor. Hence, we can't have several datasets that use different metadata columns, without them interfering with each other. This caused odd test failures because test results now depend on the order in which tests are executed.