### PR TITLE
ENH: Add tests for use of checkpoints in inference_only mode

### DIFF
--- a/hi-ml/.vscode/settings.json
+++ b/hi-ml/.vscode/settings.json
@@ -63,5 +63,10 @@
     "${workspaceFolder}/../hi-ml-azure/testazure",
     "${workspaceFolder}/src",
     "${workspaceFolder}/testhiml"
-  ]
+  ],
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#94036b",
+    "titleBar.activeBackground": "#38194a",
+    "titleBar.activeForeground": "#F6FBFA"
+  }
 }


### PR DESCRIPTION
Ensure that the test set metrics are correctly reproduced when using the runner in inference-only mode