### PR TITLE
BUG: DeepMIL model uses training data even when running in eval mode

### DIFF
--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -78,7 +78,7 @@ RUN_RECOVERY_FILE = "most_recent_run.txt"
 SDK_NAME = "innereye"
 SDK_VERSION = "2.0"
 
-DEFAULT_DOCKER_BASE_IMAGE = "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.3-cudnn8-ubuntu20.04"
+DEFAULT_DOCKER_BASE_IMAGE = "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.3-cudnn8-ubuntu20.04:20230509.v1"
 DEFAULT_DOCKER_SHM_SIZE = "100g"
 
 # hyperparameter search args

--- a/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
@@ -297,7 +297,6 @@ class BaseMIL(LightningContainer, LoadingParams, EncoderParams, PoolingParams, C
 
     def create_model(self) -> DeepMILModule:
         num_classes = self.get_num_classes()
-
         outputs_handler = self.get_outputs_handler()
         deepmil_module = DeepMILModule(
             label_column=self.get_label_column(),

--- a/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
@@ -260,7 +260,7 @@ class BaseMIL(LightningContainer, LoadingParams, EncoderParams, PoolingParams, C
         :return: A data module.
         """
         if self.data_module is None:
-            if self.runner_mode == RunnerMode.TRAINING:
+            if self.runner_mode == RunnerMode.TRAIN:
                 self.data_module = self.get_data_module()
             elif self.runner_mode == RunnerMode.EVAL_FULL:
                 self.data_module = self.get_eval_data_module()

--- a/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
+++ b/hi-ml-cpath/src/health_cpath/configs/classification/BaseMIL.py
@@ -109,9 +109,6 @@ class BaseMIL(LightningContainer, LoadingParams, EncoderParams, PoolingParams, C
     )
 
     def __init__(self, **kwargs: Any) -> None:
-        """
-        :param eval_num_classes: Number of classes to use when running in eval mode. This is provided because
-            the eval dataset may not contain all classes that the model was trained on. Defaults to 2."""
         super().__init__(**kwargs)
         self.data_module: Optional[HistoDataModule] = None
         self.run_extra_val_epoch = True  # Enable running an additional validation step to save tiles/slides thumbnails

--- a/hi-ml-cpath/testhisto/testhisto/models/test_deepmil.py
+++ b/hi-ml-cpath/testhisto/testhisto/models/test_deepmil.py
@@ -708,7 +708,7 @@ def test_checkpoint_name(
 def test_on_run_extra_val_epoch(mock_panda_tiles_root_dir: Path) -> None:
     container = MockDeepSMILETilesPanda(tmp_path=mock_panda_tiles_root_dir)
     container.setup()
-    container.data_module = MagicMock()
+    container.data_module = MagicMock(class_weights=torch.ones(2), train_dataset=MagicMock(n_classes=1))
     container.create_lightning_module_and_store()
     assert not container.model._on_extra_val_epoch
     assert (

--- a/hi-ml-cpath/testhisto/testhisto/models/test_deepmil.py
+++ b/hi-ml-cpath/testhisto/testhisto/models/test_deepmil.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch, DEFAULT
 
 import pytest
 import torch
-from pytorch_lightning import Trainer
+from pytorch_lightning import LightningDataModule, Trainer
 from torch import Tensor, allclose, argmax, nn, rand, randint, randn, round, stack
 from torch.utils.data import DataLoader
 from torch.utils.data._utils.collate import default_collate
@@ -850,3 +850,38 @@ def test_create_model_in_eval_mode(tmp_path: Path, runner_mode: RunnerMode) -> N
             get_data_module.assert_called_once()
         else:
             get_data_module.assert_not_called()
+
+
+def test_setup_model_in_eval_mode(tmp_path: Path) -> None:
+    """When the runner is in eval mode, ensure a checkpoint can be loaded correctly."""
+    # Mock a training dataset with two classes, but this is represented as n_classes=1 in the run we are trying
+    # to repro here
+    get_data_module = MagicMock(
+        return_value=MagicMock(class_weights=torch.ones(2), train_dataset=MagicMock(n_classes=1))
+    )
+    with patch.multiple(
+        "health_cpath.configs.classification.BaseMIL.BaseMIL",
+        get_data_module=get_data_module,
+        get_label_column=MagicMock(return_value="label"),
+        get_eval_data_module=MagicMock(return_value=LightningDataModule.from_datasets([], [], [])),
+    ):
+        container_orig = BaseMIL(encoder_type="Resnet18", pool_type="MeanPoolingLayer")
+        model = container_orig.create_model()
+        # Create a trainer to save a checkpoint only
+        trainer = Trainer()
+        trainer.strategy.model = model
+        checkpoint = tmp_path / "model.ckpt"
+        trainer.save_checkpoint(checkpoint)
+        # Now create the model again and run it in eval mode, loading the checkpoint
+        container = BaseMIL(encoder_type="Resnet18", pool_type="MeanPoolingLayer")
+        container.src_checkpoint = CheckpointParser(str(checkpoint))
+        eval_runner = EvalRunner(
+            container=container, experiment_config=ExperimentConfig(mode=RunnerMode.EVAL_FULL), project_root=tmp_path
+        )
+        eval_runner.setup()
+        # Before bug fix:
+        # Error(s) in loading state_dict for DeepMILModule:
+        # 	Unexpected key(s) in state_dict: "loss_fn.pos_weight", "loss_fn_no_reduction.pos_weight".
+        # 	size mismatch for classifier_fn.weight: copying a param with shape torch.Size([1, 512]) from checkpoint, the shape in current model is torch.Size([2, 512]).
+        # 	size mismatch for classifier_fn.bias: copying a param with shape torch.Size([1]) from checkpoint, the shape in current model is torch.Size([2]).
+        eval_runner.run()

--- a/hi-ml-cpath/testhisto/testhisto/models/test_deepmil.py
+++ b/hi-ml-cpath/testhisto/testhisto/models/test_deepmil.py
@@ -708,7 +708,10 @@ def test_checkpoint_name(
 def test_on_run_extra_val_epoch(mock_panda_tiles_root_dir: Path) -> None:
     container = MockDeepSMILETilesPanda(tmp_path=mock_panda_tiles_root_dir)
     container.setup()
-    container.data_module = MagicMock(class_weights=torch.ones(2), train_dataset=MagicMock(n_classes=1))
+    num_classes = 6
+    container.data_module = MagicMock(
+        class_weights=torch.ones(num_classes), train_dataset=MagicMock(n_classes=num_classes)
+    )
     container.create_lightning_module_and_store()
     assert not container.model._on_extra_val_epoch
     assert (
@@ -882,6 +885,8 @@ def test_setup_model_in_eval_mode(tmp_path: Path) -> None:
         # Before bug fix:
         # Error(s) in loading state_dict for DeepMILModule:
         # 	Unexpected key(s) in state_dict: "loss_fn.pos_weight", "loss_fn_no_reduction.pos_weight".
-        # 	size mismatch for classifier_fn.weight: copying a param with shape torch.Size([1, 512]) from checkpoint, the shape in current model is torch.Size([2, 512]).
-        # 	size mismatch for classifier_fn.bias: copying a param with shape torch.Size([1]) from checkpoint, the shape in current model is torch.Size([2]).
+        # 	size mismatch for classifier_fn.weight: copying a param with shape torch.Size([1, 512]) from checkpoint,
+        #       the shape in current model is torch.Size([2, 512]).
+        # 	size mismatch for classifier_fn.bias: copying a param with shape torch.Size([1]) from checkpoint,
+        #       the shape in current model is torch.Size([2]).
         eval_runner.run()

--- a/hi-ml/src/health_ml/lightning_container.py
+++ b/hi-ml/src/health_ml/lightning_container.py
@@ -15,7 +15,7 @@ from torch.optim.lr_scheduler import _LRScheduler
 
 from health_azure.utils import create_from_matching_params
 from health_ml.deep_learning_config import DatasetParams, OptimizerParams, OutputParams, TrainerParams, WorkflowParams
-from health_ml.experiment_config import ExperimentConfig
+from health_ml.experiment_config import ExperimentConfig, RunnerMode
 from health_ml.utils.checkpoint_utils import get_best_checkpoint_path
 from health_ml.utils.lr_scheduler import SchedulerWithWarmUp
 from health_ml.utils.model_util import create_optimizer
@@ -32,8 +32,10 @@ class LightningContainer(WorkflowParams, DatasetParams, OutputParams, TrainerPar
         super().__init__(**kwargs)
         self._model: Optional[LightningModule] = None
         self._model_name = type(self).__name__
-        self.num_nodes = 1
         self.trained_weights_path: Optional[Path] = None
+        # Number of nodes and the runner mode are read from the ExperimentConfig, and will be copied here
+        self.num_nodes = 1
+        self.runner_mode = RunnerMode.TRAIN
 
     def validate(self) -> None:
         WorkflowParams.validate(self)

--- a/hi-ml/src/health_ml/runner_base.py
+++ b/hi-ml/src/health_ml/runner_base.py
@@ -68,6 +68,7 @@ class RunnerBase:
         self.container = container
         self.experiment_config = experiment_config
         self.container.num_nodes = self.experiment_config.num_nodes
+        self.container.runner_mode = self.experiment_config.mode
         self.project_root: Path = project_root or fixed_paths.repository_root_directory()
         self.storing_logger: Optional[StoringLogger] = None
         self._has_setup_run = False

--- a/hi-ml/src/health_ml/utils/split_dataset.py
+++ b/hi-ml/src/health_ml/utils/split_dataset.py
@@ -30,14 +30,14 @@ class DatasetSplits:
     def __post_init__(self) -> None:
         common_utils.check_properties_are_not_none(self)
 
-        def pairwise_intersection(*collections: Iterable[Iterable]) -> Set:
+        def pairwise_intersection(*collections: Iterable) -> Set:
             """
             Returns any element that appears in more than one collection
 
             :return: a Set of elements that appear in more than one collection
             """
             intersection = set()
-            for col1, col2 in combinations(map(set, collections), 2):
+            for col1, col2 in combinations(map(set, collections), 2):  # type: ignore
                 intersection |= col1 & col2
             return intersection
 

--- a/hi-ml/src/health_ml/utils/split_dataset.py
+++ b/hi-ml/src/health_ml/utils/split_dataset.py
@@ -30,7 +30,7 @@ class DatasetSplits:
     def __post_init__(self) -> None:
         common_utils.check_properties_are_not_none(self)
 
-        def pairwise_intersection(*collections: Iterable) -> Set:
+        def pairwise_intersection(*collections: Iterable[Iterable]) -> Set:
             """
             Returns any element that appears in more than one collection
 

--- a/hi-ml/testhiml/testhiml/test_split_dataset.py
+++ b/hi-ml/testhiml/testhiml/test_split_dataset.py
@@ -24,7 +24,7 @@ def test_split_by_subject_ids() -> None:
     test_df, test_ids, train_ids, val_ids = _get_test_df()
     splits = DatasetSplits.from_subject_ids(test_df, train_ids, test_ids, val_ids, subject_column=CSV_SUBJECT_HEADER)
 
-    for x, y in zip([splits.train, splits.test, splits.val], [train_ids, test_ids, val_ids]):
+    for x, y in zip([splits.train, splits.test, splits.val], [train_ids, test_ids, val_ids]):  # type: ignore
         pd.testing.assert_frame_equal(x, test_df[test_df.subject.isin(y)])
 
 
@@ -66,7 +66,7 @@ def _check_is_partition(total: pd.DataFrame, parts: Iterable[pd.DataFrame], colu
     total = set(total[column].unique())
     parts = [set(part[column].unique()) for part in parts]
     assert total == set.union(*parts)
-    for part1, part2 in combinations(parts, 2):
+    for part1, part2 in combinations(parts, 2):  # type: ignore
         assert part1.isdisjoint(part2)
 
 


### PR DESCRIPTION
Instantiating the DeepMIL classifier in `create_model` always relies on the training dataset and module, which is not available when doing evaluation. This PR makes that more flexible and allows to hardcode the number of classes to use for evaluation.