### PR TITLE
BUG: Fix KeyError when converting svs to tiff

### DIFF
--- a/hi-ml-cpath/src/health_cpath/preprocessing/tiff_conversion.py
+++ b/hi-ml-cpath/src/health_cpath/preprocessing/tiff_conversion.py
@@ -214,7 +214,10 @@ class ConvertWSIToTiffd(MapTransform):
         :return: A tuple of floats (x_resolution, y_resolution)
         """
         um_per_cm = 10000
-        um_per_px = self.wsi_reader.get_mpp(wsi_obj, level=level)
+        try:
+            um_per_px = self.wsi_reader.get_mpp(wsi_obj, level=level)
+        except KeyError:
+            um_per_px = (wsi_obj.properties["openslide.mpp-x"], wsi_obj.properties["openslide.mpp-y"])
         px_per_cm = (um_per_cm / um_per_px[0], um_per_cm / um_per_px[1])
         return px_per_cm
 


### PR DESCRIPTION
svs has different metadata properties than Tiff and NDPI. This fix handles the case when get_mpp from monai fails with a KeyError exception missing "Tiff.XResolution" and "Tiff.YResolution" 