### PR TITLE
ENH: Add AzureCLI authentication for SDK v1 codepath

### DIFF
--- a/hi-ml-azure/run_requirements.txt
+++ b/hi-ml-azure/run_requirements.txt
@@ -1,4 +1,5 @@
 azure-ai-ml>=1.1.1
+azure-cli>=2.30.0
 azureml-core>=1.42.0
 azureml-dataset-runtime[fuse]>=1.42.0
 azureml-mlflow>=1.42.0

--- a/hi-ml-azure/src/health_azure/auth.py
+++ b/hi-ml-azure/src/health_azure/auth.py
@@ -1,0 +1,202 @@
+import logging
+import os
+from typing import Union, Optional
+
+from azureml.core.authentication import (
+    InteractiveLoginAuthentication,
+    ServicePrincipalAuthentication,
+    AzureCliAuthentication,
+)
+from azureml.exceptions import AuthenticationException
+from azure.core.exceptions import ClientAuthenticationError
+from azure.core.credentials import TokenCredential
+from azure.identity import (
+    ClientSecretCredential,
+    DeviceCodeCredential,
+    DefaultAzureCredential,
+    InteractiveBrowserCredential,
+)
+
+
+logger = logging.getLogger(__name__)
+
+# Environment variables used for authentication
+ENV_SERVICE_PRINCIPAL_ID = "HIML_SERVICE_PRINCIPAL_ID"
+ENV_SERVICE_PRINCIPAL_PASSWORD = "HIML_SERVICE_PRINCIPAL_PASSWORD"
+ENV_TENANT_ID = "HIML_TENANT_ID"
+
+
+def get_secret_from_environment(name: str, allow_missing: bool = False) -> Optional[str]:
+    """
+    Gets a password or key from the secrets file or environment variables.
+
+    :param name: The name of the environment variable to read. It will be converted to uppercase.
+    :param allow_missing: If true, the function returns None if there is no entry of the given name in any of the
+        places searched. If false, missing entries will raise a ValueError.
+    :return: Value of the secret. None, if there is no value and allow_missing is True.
+    """
+    name = name.upper()
+    value = os.environ.get(name, None)
+    if not value and not allow_missing:
+        raise ValueError(f"There is no value stored for the secret named '{name}'")
+    return value
+
+
+def get_authentication() -> (
+    Union[AzureCliAuthentication, InteractiveLoginAuthentication, ServicePrincipalAuthentication]
+):
+    """
+    Creates an authentication object to use with AzureML SDK v1 operation. It first tries to create a service principal
+    authentication object, initialized from environment variables. If that is not possible, try Azure CLI
+    authentication, and if that is also not possible because the user is not logged in, try interactive authentication.
+
+    :return: An authentication objects to use with AzureML SDK v1 operations.
+    """
+    service_principal_id = get_secret_from_environment(ENV_SERVICE_PRINCIPAL_ID, allow_missing=True)
+    tenant_id = get_secret_from_environment(ENV_TENANT_ID, allow_missing=True)
+    service_principal_password = get_secret_from_environment(ENV_SERVICE_PRINCIPAL_PASSWORD, allow_missing=True)
+    # Check if all 3 environment variables are set
+    if service_principal_id and tenant_id and service_principal_password:
+        logger.info(
+            "Found environment variables for Service Principal authentication: First characters of App ID "
+            f"are {service_principal_id[:8]}... in tenant {tenant_id[:8]}..."
+        )
+        return ServicePrincipalAuthentication(
+            tenant_id=tenant_id,
+            service_principal_id=service_principal_id,
+            service_principal_password=service_principal_password,
+        )
+    try:
+        logger.debug("Trying to authenticate using Azure CLI")
+        auth = AzureCliAuthentication()
+        _ = auth.get_token()
+        logger.info("Successfully started AzureCLI authentication.")
+        return auth
+    except AuthenticationException:
+        pass
+
+    logger.info(
+        "Using interactive login to Azure. To use Service Principal authentication, set the environment "
+        f"variables {ENV_SERVICE_PRINCIPAL_ID}, {ENV_SERVICE_PRINCIPAL_PASSWORD}, and {ENV_TENANT_ID}. "
+        "For Azure CLI authentication, log in using 'az login' and ensure that the subscription is set."
+    )
+    return InteractiveLoginAuthentication()
+
+
+def _validate_credential(credential: TokenCredential) -> None:
+    """
+    Validate credential by attempting to get token. If authentication has been successful, get_token
+    will succeed. Otherwise an exception will be raised
+
+    :param credential: The credential object to validate.
+    """
+    credential.get_token("https://management.azure.com/.default")
+
+
+def _get_legitimate_service_principal_credential(
+    tenant_id: str, service_principal_id: str, service_principal_password: str
+) -> TokenCredential:
+    """
+    Create a ClientSecretCredential given a tenant id, service principal id and password
+
+    :param tenant_id: The Azure tenant id.
+    :param service_principal_id: The id of an existing Service Principal.
+    :param service_principal_password: The password of an existing Service Principal.
+    :raises ValueError: If the credential cannot be validated (i.e. authentication was unsucessful).
+    :return: The validated credential.
+    """
+    cred = ClientSecretCredential(
+        tenant_id=tenant_id, client_id=service_principal_id, client_secret=service_principal_password
+    )
+    try:
+        _validate_credential(cred)
+        return cred
+    except ClientAuthenticationError as e:
+        raise ValueError(
+            f"Found environment variables for {ENV_SERVICE_PRINCIPAL_ID}, "
+            f"{ENV_SERVICE_PRINCIPAL_PASSWORD}, and {ENV_TENANT_ID} but was "
+            f"not able to authenticate"
+        ) from e
+
+
+def _get_legitimate_device_code_credential() -> Optional[TokenCredential]:
+    """
+    Create a DeviceCodeCredential for interacting with Azure resources. If the credential can't be
+    validated, return None.
+
+    :return: A valid Azure credential.
+    """
+    cred = DeviceCodeCredential(timeout=60)
+    try:
+        _validate_credential(cred)
+        return cred
+    except ClientAuthenticationError:
+        return None
+
+
+def _get_legitimate_default_credential() -> Optional[TokenCredential]:
+    """
+    Create a DefaultAzure credential for interacting with Azure resources and validates it.
+
+    :return: A valid Azure credential.
+    """
+    cred = DefaultAzureCredential(timeout=60)
+    _validate_credential(cred)
+    return cred
+
+
+def _get_legitimate_interactive_browser_credential() -> Optional[TokenCredential]:
+    """
+    Create an InteractiveBrowser credential for interacting with Azure resources. If the credential can't be
+    validated, return None.
+
+    :return: A valid Azure credential.
+    """
+    cred = InteractiveBrowserCredential(timeout=60)
+    try:
+        _validate_credential(cred)
+        return cred
+    except ClientAuthenticationError:
+        return None
+
+
+def get_credential() -> Optional[TokenCredential]:
+    """
+    Get a credential for authenticating with Azure. There are multiple ways to retrieve a credential.
+    If environment variables pertaining to details of a Service Principal are available, those will be used
+    to authenticate. If no environment variables exist, and the script is not currently
+    running inside of Azure ML or another Azure agent, will attempt to retrieve a credential via a
+    device code (which requires the user to visit a link and enter a provided code). If this fails, or if running in
+    Azure, DefaultAzureCredential will be used which iterates through a number of possible authentication methods
+    including identifying an Azure managed identity, cached credentials from VS code, Azure CLI, Powershell etc.
+    Otherwise returns None.
+
+    :return: Any of the aforementioned credentials if available, else None.
+    """
+    service_principal_id = get_secret_from_environment(ENV_SERVICE_PRINCIPAL_ID, allow_missing=True)
+    tenant_id = get_secret_from_environment(ENV_TENANT_ID, allow_missing=True)
+    service_principal_password = get_secret_from_environment(ENV_SERVICE_PRINCIPAL_PASSWORD, allow_missing=True)
+    if service_principal_id and tenant_id and service_principal_password:
+        logger.info(
+            "Found environment variables for Service Principal authentication: First characters of App ID "
+            f"are {service_principal_id[:8]}... in tenant {tenant_id[:8]}..."
+        )
+        return _get_legitimate_service_principal_credential(tenant_id, service_principal_id, service_principal_password)
+
+    try:
+        cred = _get_legitimate_default_credential()
+        if cred is not None:
+            return cred
+    except ClientAuthenticationError:
+        cred = _get_legitimate_device_code_credential()
+        if cred is not None:
+            return cred
+
+        cred = _get_legitimate_interactive_browser_credential()
+        if cred is not None:
+            return cred
+
+    raise ValueError(
+        "Unable to generate and validate a credential. Please see Azure ML documentation"
+        "for instructions on different options to get a credential"
+    )

--- a/hi-ml-azure/testazure/testazure/test_get_ml_client.py
+++ b/hi-ml-azure/testazure/testazure/test_get_ml_client.py
@@ -13,17 +13,19 @@ import pytest
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import ClientSecretCredential, DefaultAzureCredential, DeviceCodeCredential
 
-from health_azure.utils import (
-    ENV_RESOURCE_GROUP,
+from health_azure.auth import (
+    get_credential,
     ENV_SERVICE_PRINCIPAL_ID,
     ENV_SERVICE_PRINCIPAL_PASSWORD,
-    ENV_SUBSCRIPTION_ID,
     ENV_TENANT_ID,
-    ENV_WORKSPACE_NAME,
     _get_legitimate_default_credential,
     _get_legitimate_device_code_credential,
     _get_legitimate_service_principal_credential,
-    get_credential,
+)
+from health_azure.utils import (
+    ENV_RESOURCE_GROUP,
+    ENV_SUBSCRIPTION_ID,
+    ENV_WORKSPACE_NAME,
     get_ml_client,
 )
 

--- a/hi-ml-azure/testazure/testazure/test_get_ml_client.py
+++ b/hi-ml-azure/testazure/testazure/test_get_ml_client.py
@@ -42,73 +42,69 @@ def test_get_credential() -> None:
         ENV_SERVICE_PRINCIPAL_PASSWORD: "baz",
     }
 
-    with patch.dict(os.environ, mock_env_vars):
-        with patch.multiple(
-            "health_azure.utils",
-            is_running_in_azure_ml=DEFAULT,
-            is_running_on_azure_agent=DEFAULT,
-            _get_legitimate_service_principal_credential=DEFAULT,
-            _get_legitimate_device_code_credential=DEFAULT,
-            _get_legitimate_default_credential=DEFAULT,
-            _get_legitimate_interactive_browser_credential=DEFAULT,
-        ) as mocks:
-            mocks["is_running_in_azure_ml"].return_value = False
-            mocks["is_running_on_azure_agent"].return_value = False
-            _ = get_credential()
-            mocks["_get_legitimate_service_principal_credential"].assert_called_once()
-            mocks["_get_legitimate_device_code_credential"].assert_not_called()
-            mocks["_get_legitimate_default_credential"].assert_not_called()
-            mocks["_get_legitimate_interactive_browser_credential"].assert_not_called()
+    with patch.multiple(
+        "health_azure.utils",
+        is_running_in_azure_ml=MagicMock(return_value=False),
+        is_running_on_azure_agent=MagicMock(return_value=False),
+    ):
+        with patch.dict(os.environ, mock_env_vars):
+            with patch.multiple(
+                "health_azure.auth",
+                _get_legitimate_service_principal_credential=DEFAULT,
+                _get_legitimate_device_code_credential=DEFAULT,
+                _get_legitimate_default_credential=DEFAULT,
+                _get_legitimate_interactive_browser_credential=DEFAULT,
+            ) as mocks:
+                _ = get_credential()
+                mocks["_get_legitimate_service_principal_credential"].assert_called_once()
+                mocks["_get_legitimate_device_code_credential"].assert_not_called()
+                mocks["_get_legitimate_default_credential"].assert_not_called()
+                mocks["_get_legitimate_interactive_browser_credential"].assert_not_called()
 
-    # if the environment variables are not set and we are running on a local machine, a
-    # DefaultAzureCredential should be attempted first
-    with patch.object(os.environ, "get", return_value={}):
-        with patch.multiple(
-            "health_azure.utils",
-            is_running_in_azure_ml=DEFAULT,
-            is_running_on_azure_agent=DEFAULT,
-            _get_legitimate_service_principal_credential=DEFAULT,
-            _get_legitimate_device_code_credential=DEFAULT,
-            _get_legitimate_default_credential=DEFAULT,
-            _get_legitimate_interactive_browser_credential=DEFAULT,
-        ) as mocks:
-            mock_get_sp_cred = mocks["_get_legitimate_service_principal_credential"]
-            mock_get_device_cred = mocks["_get_legitimate_device_code_credential"]
-            mock_get_default_cred = mocks["_get_legitimate_default_credential"]
-            mock_get_browser_cred = mocks["_get_legitimate_interactive_browser_credential"]
+        # if the environment variables are not set and we are running on a local machine, a
+        # DefaultAzureCredential should be attempted first
+        with patch.object(os.environ, "get", return_value={}):
+            with patch.multiple(
+                "health_azure.auth",
+                _get_legitimate_service_principal_credential=DEFAULT,
+                _get_legitimate_device_code_credential=DEFAULT,
+                _get_legitimate_default_credential=DEFAULT,
+                _get_legitimate_interactive_browser_credential=DEFAULT,
+            ) as mocks:
+                mock_get_sp_cred = mocks["_get_legitimate_service_principal_credential"]
+                mock_get_device_cred = mocks["_get_legitimate_device_code_credential"]
+                mock_get_default_cred = mocks["_get_legitimate_default_credential"]
+                mock_get_browser_cred = mocks["_get_legitimate_interactive_browser_credential"]
+                _ = get_credential()
+                mock_get_sp_cred.assert_not_called()
+                mock_get_device_cred.assert_not_called()
+                mock_get_default_cred.assert_called_once()
+                mock_get_browser_cred.assert_not_called()
 
-            mocks["is_running_in_azure_ml"].return_value = False
-            mocks["is_running_on_azure_agent"].return_value = False
-            _ = get_credential()
-            mock_get_sp_cred.assert_not_called()
-            mock_get_device_cred.assert_not_called()
-            mock_get_default_cred.assert_called_once()
-            mock_get_browser_cred.assert_not_called()
+                # if that fails, a DeviceCode credential should be attempted
+                mock_get_default_cred.side_effect = _mock_validation_error
+                _ = get_credential()
+                mock_get_sp_cred.assert_not_called()
+                mock_get_device_cred.assert_called_once()
+                assert mock_get_default_cred.call_count == 2
+                mock_get_browser_cred.assert_not_called()
 
-            # if that fails, a DeviceCode credential should be attempted
-            mock_get_default_cred.side_effect = _mock_validation_error
-            _ = get_credential()
-            mock_get_sp_cred.assert_not_called()
-            mock_get_device_cred.assert_called_once()
-            assert mock_get_default_cred.call_count == 2
-            mock_get_browser_cred.assert_not_called()
+                # if None of the previous credentials work, an InteractiveBrowser credential should be tried
+                mock_get_device_cred.return_value = None
+                _ = get_credential()
+                mock_get_sp_cred.assert_not_called()
+                assert mock_get_device_cred.call_count == 2
+                assert mock_get_default_cred.call_count == 3
+                mock_get_browser_cred.assert_called_once()
 
-            # if None of the previous credentials work, an InteractiveBrowser credential should be tried
-            mock_get_device_cred.return_value = None
-            _ = get_credential()
-            mock_get_sp_cred.assert_not_called()
-            assert mock_get_device_cred.call_count == 2
-            assert mock_get_default_cred.call_count == 3
-            mock_get_browser_cred.assert_called_once()
-
-            # finally, if none of the methods work, an Exception should be raised
-            mock_get_browser_cred.return_value = None
-            with pytest.raises(Exception) as e:
-                get_credential()
-                assert (
-                    "Unable to generate and validate a credential. Please see Azure ML documentation"
-                    "for instructions on different options to get a credential" in str(e)
-                )
+                # finally, if none of the methods work, an Exception should be raised
+                mock_get_browser_cred.return_value = None
+                with pytest.raises(Exception) as e:
+                    get_credential()
+                    assert (
+                        "Unable to generate and validate a credential. Please see Azure ML documentation"
+                        "for instructions on different options to get a credential" in str(e)
+                    )
 
 
 @pytest.mark.fast
@@ -127,7 +123,7 @@ def test_get_legitimate_service_principal_credential() -> None:
         assert expected_error_msg in str(e)
 
     # now mock the case where validating the credential succeeds and check the value of that
-    with patch("health_azure.utils._validate_credential"):
+    with patch("health_azure.auth._validate_credential"):
         cred = _get_legitimate_service_principal_credential(
             mock_tenant_id, mock_service_principal_id, mock_service_principal_password
         )
@@ -139,12 +135,12 @@ def test_get_legitimate_device_code_credential() -> None:
     def _mock_credential_fast_timeout(timeout: int) -> DeviceCodeCredential:
         return DeviceCodeCredential(timeout=1)
 
-    with patch("health_azure.utils.DeviceCodeCredential", new=_mock_credential_fast_timeout):
+    with patch("health_azure.auth.DeviceCodeCredential", new=_mock_credential_fast_timeout):
         cred = _get_legitimate_device_code_credential()
         assert cred is None
 
     # now mock the case where validating the credential succeeds
-    with patch("health_azure.utils._validate_credential"):
+    with patch("health_azure.auth._validate_credential"):
         cred = _get_legitimate_device_code_credential()
         assert isinstance(cred, DeviceCodeCredential)
 
@@ -154,12 +150,12 @@ def test_get_legitimate_default_credential() -> None:
     def _mock_credential_fast_timeout(timeout: int) -> DefaultAzureCredential:
         return DefaultAzureCredential(timeout=1)
 
-    with patch("health_azure.utils.DefaultAzureCredential", new=_mock_credential_fast_timeout):
+    with patch("health_azure.auth.DefaultAzureCredential", new=_mock_credential_fast_timeout):
         exception_message = r"DefaultAzureCredential failed to retrieve a token from the included credentials."
         with pytest.raises(ClientAuthenticationError, match=exception_message):
             cred = _get_legitimate_default_credential()
 
-    with patch("health_azure.utils._validate_credential"):
+    with patch("health_azure.auth._validate_credential"):
         cred = _get_legitimate_default_credential()
         assert isinstance(cred, DefaultAzureCredential)
 

--- a/hi-ml-azure/testazure/testazure/test_get_workspace.py
+++ b/hi-ml-azure/testazure/testazure/test_get_workspace.py
@@ -240,7 +240,9 @@ def test_auth_azure_cli() -> None:
 
         # If token retrieval raises an AuthenticationException: return InteractiveLoginAuthentication
         mock_raise = MagicMock(side_effect=AuthenticationException("foo"))
+        mock_interactive = "mock_interactive"
         with patch.object(AzureCliAuthentication, "get_token", mock_raise) as mock_azure_cli:
-            auth = get_authentication()
-            mock_azure_cli.assert_called_once()
-            assert isinstance(auth, InteractiveLoginAuthentication), "Expected InteractiveAuth if AzureCLI fails"
+            with patch("health_azure.auth.InteractiveLoginAuthentication", return_value=mock_interactive):
+                auth = get_authentication()
+                mock_azure_cli.assert_called_once()
+                assert auth == mock_interactive, "Expected InteractiveAuth if AzureCLI fails"

--- a/hi-ml-azure/testazure/testazure/test_get_workspace.py
+++ b/hi-ml-azure/testazure/testazure/test_get_workspace.py
@@ -15,17 +15,15 @@ from _pytest.logging import LogCaptureFixture
 import pytest
 from unittest.mock import MagicMock, patch
 
-from health_azure.utils import (
-    find_file_in_parent_folders,
-    find_file_in_parent_to_pythonpath,
-    get_authentication,
+from health_azure.auth import (
     get_secret_from_environment,
-    get_workspace,
-)
-from health_azure.utils import (
+    get_authentication,
     ENV_SERVICE_PRINCIPAL_ID,
     ENV_SERVICE_PRINCIPAL_PASSWORD,
     ENV_TENANT_ID,
+)
+from health_azure.utils import find_file_in_parent_folders, find_file_in_parent_to_pythonpath, get_workspace
+from health_azure.utils import (
     ENV_WORKSPACE_NAME,
     ENV_SUBSCRIPTION_ID,
     ENV_RESOURCE_GROUP,
@@ -98,7 +96,7 @@ def test_find_file_in_parent_folders(caplog: LogCaptureFixture) -> None:
 
 
 @pytest.mark.fast
-@patch("health_azure.utils.InteractiveLoginAuthentication")
+@patch("health_azure.auth.InteractiveLoginAuthentication")
 def test_get_authentication(mock_interactive_authentication: MagicMock) -> None:
     with patch.dict(os.environ, {}, clear=True):
         get_authentication()

--- a/hi-ml-azure/testazure/testazure/test_get_workspace.py
+++ b/hi-ml-azure/testazure/testazure/test_get_workspace.py
@@ -227,6 +227,7 @@ def test_auth_azure_cli() -> None:
     mock_env_vars = {
         ENV_SERVICE_PRINCIPAL_ID: "foo",
         ENV_TENANT_ID: "bar",
+        ENV_SERVICE_PRINCIPAL_PASSWORD: "",
     }
 
     # Patch environment variables to have no service principal


### PR DESCRIPTION
At present, only ServicePrincipal and InteractiveAuthentication are supported for AzureML SDK v1. This PR adds AzureCLI as a third option. This sets the stage for password-free authentication in pipelines