### PR TITLE
ENH: Add support to return the job after submitting a run

### DIFF
--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -828,7 +828,9 @@ def submit_to_azure_if_needed(  # type: ignore
     :param: hyperdrive_argument_prefix: Prefix to add to hyperparameter arguments. Some examples might be "--", "-"
         or "". For example, if "+" is used, a hyperparameter "learning_rate" with value 0.01 will be passed as
         `+learning_rate=0.01`.
-    :param exit_on_completion: If True, exit the Python process after the run is submitted.
+    :param exit_on_completion: If True, exit the Python process after the AzureML job is submitted. If False,
+        return the submitted Run object (when using the `strictly_aml_v1=True` flag) or the submitted Job object (when using `strictly_aml_v1=False` flag)
+        the 
     :return: If the script is submitted to AzureML and `exit_on_completion` is True then the Python process will be
         terminated. Otherwise, we return either the AzureRunInfo object if `submit_to_azureml` is False, the submitted
         Run object if the job is submitted using AzureML SDK v1, or the submitted Job object if the job is submitted

--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -749,7 +749,8 @@ def submit_to_azure_if_needed(  # type: ignore
     display_name: Optional[str] = None,
     entry_command: Optional[PathOrString] = None,
     hyperdrive_argument_prefix: str = "--",
-) -> AzureRunInfo:  # pragma: no cover
+    exit_on_completion: bool = True,
+) -> Union[AzureRunInfo, Run, Job]:  # pragma: no cover
     """
     Submit a folder to Azure, if needed and run it.
     Use the commandline flag --azureml to submit to AzureML, and leave it out to run locally.
@@ -827,8 +828,11 @@ def submit_to_azure_if_needed(  # type: ignore
     :param: hyperdrive_argument_prefix: Prefix to add to hyperparameter arguments. Some examples might be "--", "-"
         or "". For example, if "+" is used, a hyperparameter "learning_rate" with value 0.01 will be passed as
         `+learning_rate=0.01`.
-    :return: If the script is submitted to AzureML then we terminate python as the script should be executed in AzureML,
-        otherwise we return a AzureRunInfo object.
+    :param exit_on_completion: If True, exit the Python process after the run is submitted.
+    :return: If the script is submitted to AzureML and `exit_on_completion` is True then the Python process will be
+        terminated. Otherwise, we return either the AzureRunInfo object if `submit_to_azureml` is False, the submitted
+        Run object if the job is submitted using AzureML SDK v1, or the submitted Job object if the job is submitted
+        using AzureML SDK v2.
     """
     health_azure_package_setup()
     workspace_config_path = _str_to_path(workspace_config_file)
@@ -962,6 +966,10 @@ def submit_to_azure_if_needed(  # type: ignore
             )
             if after_submission is not None:
                 after_submission(run)  # type: ignore
+
+            if not exit_on_completion:
+                return run
+
         else:
             assert ml_client is not None, "An AzureML MLClient should have been created already."
             if conda_environment_file is None:
@@ -999,6 +1007,9 @@ def submit_to_azure_if_needed(  # type: ignore
 
             if after_submission is not None:
                 after_submission(job, ml_client)  # type: ignore
+
+            if not exit_on_completion:
+                return job
 
     exit(0)
 

--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -1012,10 +1012,10 @@ def submit_to_azure_if_needed(  # type: ignore
             if after_submission is not None:
                 after_submission(job, ml_client)  # type: ignore
 
-            if not exit_on_completion:
+            if exit_on_completion:
+                exit(0)
+            else:
                 return job
-
-    exit(0)
 
 
 def _write_run_recovery_file(run: Run) -> None:

--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -830,7 +830,7 @@ def submit_to_azure_if_needed(  # type: ignore
         `+learning_rate=0.01`.
     :param exit_on_completion: If True, exit the Python process after the AzureML job is submitted. If False,
         return the submitted Run object (when using the `strictly_aml_v1=True` flag) or the submitted Job object (when using `strictly_aml_v1=False` flag)
-        the 
+        the
     :return: If the script is submitted to AzureML and `exit_on_completion` is True then the Python process will be
         terminated. Otherwise, we return either the AzureRunInfo object if `submit_to_azureml` is False, the submitted
         Run object if the job is submitted using AzureML SDK v1, or the submitted Job object if the job is submitted

--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -829,8 +829,8 @@ def submit_to_azure_if_needed(  # type: ignore
         or "". For example, if "+" is used, a hyperparameter "learning_rate" with value 0.01 will be passed as
         `+learning_rate=0.01`.
     :param exit_on_completion: If True, exit the Python process after the AzureML job is submitted. If False,
-        return the submitted Run object (when using the `strictly_aml_v1=True` flag) or the submitted Job object (when using `strictly_aml_v1=False` flag)
-        the
+        return the submitted Run object (when using the `strictly_aml_v1=True` flag) or the submitted Job object (when
+        using `strictly_aml_v1=False` flag).
     :return: If the script is submitted to AzureML and `exit_on_completion` is True then the Python process will be
         terminated. Otherwise, we return either the AzureRunInfo object if `submit_to_azureml` is False, the submitted
         Run object if the job is submitted using AzureML SDK v1, or the submitted Job object if the job is submitted

--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -969,7 +969,9 @@ def submit_to_azure_if_needed(  # type: ignore
             if after_submission is not None:
                 after_submission(run)  # type: ignore
 
-            if not exit_on_completion:
+            if exit_on_completion:
+                exit(0)
+            else:
                 return run
 
         else:

--- a/hi-ml-azure/testazure/testazure/test_himl.py
+++ b/hi-ml-azure/testazure/testazure/test_himl.py
@@ -1798,10 +1798,12 @@ def test_create_v2_outputs() -> None:
     assert output.mode == InputOutputModes.MOUNT
 
 
-def test_submit_to_azure_if_needed_v2() -> None:
+@pytest.mark.parametrize("exit_on_completion", [True, False])
+def test_submit_to_azure_if_needed_v2(exit_on_completion: bool) -> None:
     """
     Check that submit_run_v2 is called when submit_to_azure_if_needed is called, unless strictly_aml_v1 is
-    set to True, in which case submit_run should be called instead
+    set to True, in which case submit_run should be called instead.
+    It also tests the "exit_on_completion" parameter.
     """
     dummy_input_datasets: List[Optional[Path]] = []
     dummy_mount_contexts: List[Any] = []
@@ -1828,9 +1830,17 @@ def test_submit_to_azure_if_needed_v2() -> None:
                     snapshot_root_directory="dummy",
                     submit_to_azureml=True,
                     strictly_aml_v1=False,
+                    exit_on_completion=exit_on_completion,
                 )
                 mock_submit_run_v2.assert_called_once()
-                assert return_value is None
+                if exit_on_completion:
+                    mocks["exit"].assert_called_once()
+                    assert return_value is None
+                else:
+                    mocks["exit"].assert_not_called()
+                    assert return_value == mock_submit_run_v2.return_value
+
+            mocks["exit"].reset_mock()
 
             # Now supply strictly_aml_v1=True, and check that submit_run is called
             with patch("health_azure.himl.submit_run") as mock_submit_run:
@@ -1839,9 +1849,15 @@ def test_submit_to_azure_if_needed_v2() -> None:
                     snapshot_root_directory="dummy",
                     submit_to_azureml=True,
                     strictly_aml_v1=True,
+                    exit_on_completion=exit_on_completion,
                 )
                 mock_submit_run.assert_called_once()
-                assert return_value is None
+                if exit_on_completion:
+                    mocks["exit"].assert_called_once()
+                    assert return_value == None
+                else:
+                    mocks["exit"].assert_not_called()
+                    assert return_value == mock_submit_run.return_value
 
 
 @pytest.mark.parametrize("wait_for_completion", [True, False])

--- a/hi-ml-azure/testazure/testazure/test_himl.py
+++ b/hi-ml-azure/testazure/testazure/test_himl.py
@@ -1854,7 +1854,7 @@ def test_submit_to_azure_if_needed_v2(exit_on_completion: bool) -> None:
                 mock_submit_run.assert_called_once()
                 if exit_on_completion:
                     mocks["exit"].assert_called_once()
-                    assert return_value == None
+                    assert return_value is None
                 else:
                     mocks["exit"].assert_not_called()
                     assert return_value == mock_submit_run.return_value


### PR DESCRIPTION
Currently when calling `submit_to_azure_if_needed` with `submit_to_azureml=True`, python is exited after the job is submitted. This PR adds an option `exit_on_completion` to control whether this happens. If `exit_on_completion` is `False` then the submitted `Run`/`Job` objects are returned.
