### PR TITLE
MNT: Update ref of pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/cpath-pr.yml
+++ b/.github/workflows/cpath-pr.yml
@@ -413,7 +413,7 @@ jobs:
           make test_wheel
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TEST_API_TOKEN }}
@@ -424,7 +424,7 @@ jobs:
 
       - name: Publish package to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@v1.8.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/hi-ml-pr.yml
+++ b/.github/workflows/hi-ml-pr.yml
@@ -357,7 +357,7 @@ jobs:
           folder: ${{ matrix.folder }}
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ env.PYPI_TEST_API_TOKEN }}
@@ -389,7 +389,7 @@ jobs:
           folder: ${{ matrix.folder }}
 
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ env.PYPI_API_TOKEN }}


### PR DESCRIPTION
We are getting this surprising message in our CI because we're using an old version of the GHA to publish packages:

![image](https://github.com/user-attachments/assets/989d33c5-5d73-47bc-9281-0518b2216348)

This PR uses the recommended ref for the GHA.