### PR TITLE
ENH: Add support for other hyperdrive sweep types

### DIFF
--- a/.github/actions/download_package_artifacts/action.yml
+++ b/.github/actions/download_package_artifacts/action.yml
@@ -25,19 +25,19 @@ runs:
   using: "composite"
   steps:
     - name: Download distribution artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.folder }}${{ env.HIML_DIST_ARTIFACT_SUFFIX }}
         path: ${{ inputs.folder }}/dist
 
     - name: Download package name artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.folder }}${{ env.HIML_PACKAGE_NAME_ARTIFACT_SUFFIX }}
         path: ${{ inputs.folder }}
 
     - name: Download version artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.folder }}${{ env.HIML_VERSION_ARTIFACT_SUFFIX }}
         path: ${{ inputs.folder }}

--- a/.github/actions/upload_package_artifacts/action.yml
+++ b/.github/actions/upload_package_artifacts/action.yml
@@ -8,19 +8,19 @@ runs:
   using: "composite"
   steps:
     - name: Upload distribution artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.folder }}${{ env.HIML_DIST_ARTIFACT_SUFFIX }}
         path: ${{ inputs.folder }}/dist/*
 
     - name: Upload package name artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.folder }}${{ env.HIML_PACKAGE_NAME_ARTIFACT_SUFFIX }}
         path: ${{ inputs.folder }}/package_name.txt
 
     - name: Upload version artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.folder }}${{ env.HIML_VERSION_ARTIFACT_SUFFIX }}
         path: ${{ inputs.folder }}/latest_version.txt

--- a/hi-ml-azure/testazure/testazure/test_himl.py
+++ b/hi-ml-azure/testazure/testazure/test_himl.py
@@ -782,8 +782,8 @@ def test_submit_run_v2(tmp_path: Path) -> None:
             values = [0.1, 0.5, 0.9]
             argument_name = "learning_rate"
             argument_2_name = "batch_size"
-            distribution = QUniform(8, 32, 4)
-            param_sampling = {argument_name: Choice(values), argument_2_name: distribution}  # type: ignore
+            sweep_distribution = QUniform(8, 32, 4)
+            param_sampling = {argument_name: Choice(values), argument_2_name: sweep_distribution}  # type: ignore
             metric_name = "val/loss"
 
             dummy_hyperparam_args = {
@@ -795,7 +795,7 @@ def test_submit_run_v2(tmp_path: Path) -> None:
             }
 
             # The hyperparameter to be altered should have been added to the command
-            expected_command += " --learning_rate=${{inputs.learning_rate}}"
+            expected_command += " --learning_rate=${{inputs.learning_rate}} --batch_size=${{inputs.batch_size}}"
 
             himl.submit_run_v2(
                 experiment_name=dummy_experiment_name,

--- a/hi-ml-azure/testazure/testazure/test_himl.py
+++ b/hi-ml-azure/testazure/testazure/test_himl.py
@@ -27,7 +27,7 @@ from azure.ai.ml import Input, Output, MLClient
 from azure.ai.ml.constants import AssetTypes, InputOutputModes
 from azure.ai.ml.entities import Data, Job
 from azure.ai.ml.entities._job.distribution import MpiDistribution, PyTorchDistribution
-from azure.ai.ml.sweep import Choice
+from azure.ai.ml.sweep import Choice, QUniform
 from azure.core.exceptions import ResourceNotFoundError
 from azureml._restclient.constants import RunStatus
 from azureml.core import ComputeTarget, Environment, RunConfiguration, ScriptRunConfig, Workspace
@@ -781,7 +781,9 @@ def test_submit_run_v2(tmp_path: Path) -> None:
 
             values = [0.1, 0.5, 0.9]
             argument_name = "learning_rate"
-            param_sampling = {argument_name: Choice(values)}  # type: ignore
+            argument_2_name = "batch_size"
+            distribution = QUniform(8, 32, 4)
+            param_sampling = {argument_name: Choice(values), argument_2_name: distribution}  # type: ignore
             metric_name = "val/loss"
 
             dummy_hyperparam_args = {


### PR DESCRIPTION
Currently submitting a hyperdrive run assumes that all sweep distributions are `Choice`. This PR adds support for other sweep types described [here](https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml.sweep?view=azure-python) for SDK v2 jobs.

If hydra is used for command line arguments then `/` or `.` will be in the argument names which is not supported as an input type or argument name for `command_job`. As such, these get replaced with `_`.