### PR TITLE
FIX: Switch to upload artefact v4

### DIFF
--- a/.github/actions/upload_package_artifacts/action.yml
+++ b/.github/actions/upload_package_artifacts/action.yml
@@ -8,19 +8,19 @@ runs:
   using: "composite"
   steps:
     - name: Upload distribution artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.folder }}${{ env.HIML_DIST_ARTIFACT_SUFFIX }}
         path: ${{ inputs.folder }}/dist/*
 
     - name: Upload package name artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.folder }}${{ env.HIML_PACKAGE_NAME_ARTIFACT_SUFFIX }}
         path: ${{ inputs.folder }}/package_name.txt
 
     - name: Upload version artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.folder }}${{ env.HIML_VERSION_ARTIFACT_SUFFIX }}
         path: ${{ inputs.folder }}/latest_version.txt


### PR DESCRIPTION
The CI for uploading package artefacts is failing with the following error:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

This PR switches the Github action `upload-artifact` to v4.