### PR TITLE
ENH: Allow environments from docker build contexts

### DIFF
--- a/hi-ml-azure/src/health_azure/himl.py
+++ b/hi-ml-azure/src/health_azure/himl.py
@@ -989,10 +989,15 @@ def submit_to_azure_if_needed(  # type: ignore
         else:
             assert ml_client is not None, "An AzureML MLClient should have been created already."
             if conda_environment_file is None:
-                raise ValueError("Argument 'conda_environment_file' must be specified when using AzureML v2")
-            environment = create_python_environment_v2(
-                conda_environment_file=conda_environment_file, docker_base_image=docker_base_image
-            )
+                logger.warning("No conda environment file provided. Using base docker image.")
+                environment = EnvironmentV2(
+                    image=docker_base_image,
+                )
+            else:
+                environment = create_python_environment_v2(
+                    conda_environment_file=conda_environment_file, docker_base_image=docker_base_image
+                )
+
             registered_env = register_environment_v2(environment, ml_client)
             input_datasets_v2 = create_v2_inputs(ml_client, cleaned_input_datasets)
             output_datasets_v2 = create_v2_outputs(ml_client, cleaned_output_datasets)

--- a/hi-ml-azure/src/health_azure/utils.py
+++ b/hi-ml-azure/src/health_azure/utils.py
@@ -638,6 +638,25 @@ def is_conda_file_with_pip_include(conda_file: Path) -> Tuple[bool, Dict]:
     return False, conda_yaml
 
 
+def load_and_hash_directory(folder_path: Path) -> str:
+    # Initialize an empty string to hold the concatenated contents
+    concatenated_content = b''
+
+    # Use pathlib to get all files in the folder
+    folder = Path(folder_path)
+    for filepath in folder.glob('*'):
+        # Check if it's a file (not a directory)
+        if filepath.is_file():
+            with filepath.open('rb') as file:
+                concatenated_content += file.read()
+
+    hash_object = hashlib.sha1()
+    hash_object.update(concatenated_content)
+    overall_hash = hash_object.hexdigest()[:32]
+    unique_env_name = f"HealthML-{overall_hash}"
+    return unique_env_name
+
+
 def generate_unique_environment_name(environment_description_string: str) -> str:
     """
     Generates a unique environment name beginning with "HealthML" and ending with a hash string generated


### PR DESCRIPTION
Currently environments can only be constructed from conda files. This PR allows adds the optional argument `build_context` to `submit_to_azure_if_needed` which can either be a `DockerBuildContext` for SDK v1 or a `BuildContext` for SDK v2. 

Build contexts are dockerfiles or folders containing a dockerfile that set up the docker environment.

For example to set up UV, the following dockerfile can be used
```dockerfile
FROM mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04
WORKDIR /workspace
RUN curl -LsSf https://astral.sh/uv/install.sh | sh
ENV PATH="/root/.local/bin:$PATH"
CMD ["/bin/bash"]
```

The build context folder could contain a `pyproject.toml` file and `uv sync` added to the dockerfile. Alternatively, `uv sync` can be run at the start of a job, or just `uv run` can be used to execute the script and install all depencies.