### PR TITLE
MNT: Switch release packages to normalized names

### DIFF
--- a/hi-ml-azure/setup.py
+++ b/hi-ml-azure/setup.py
@@ -53,7 +53,8 @@ if not version:
         default_random_version_number = floor(random() * 10_000_000_000)
         version = f"99.991.post{str(default_random_version_number)}"
 
-(here / "package_name.txt").write_text("hi-ml-azure")
+package_name = "hi_ml_azure"
+(here / "package_name.txt").write_text(package_name)
 (here / "latest_version.txt").write_text(version)
 
 # Read run_requirements.txt to get install_requires
@@ -64,7 +65,7 @@ install_requires = [line.strip() for line in install_requires if line.strip()]
 description = "Microsoft Health Futures package to elevate and monitor scripts to an AzureML workspace"
 
 setup(
-    name="hi-ml-azure",
+    name=package_name,
     version=version,
     description=description,
     long_description=long_description,

--- a/hi-ml-cpath/setup.py
+++ b/hi-ml-cpath/setup.py
@@ -53,7 +53,7 @@ if not version:
         default_random_version_number = floor(random() * 10_000_000_000)
         version = f"99.99.post{str(default_random_version_number)}"
 
-package_name = "hi-ml-cpath"
+package_name = "hi_ml_cpath"
 (here / "package_name.txt").write_text(package_name)
 (here / "latest_version.txt").write_text(version)
 

--- a/hi-ml-multimodal/setup.py
+++ b/hi-ml-multimodal/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_namespace_packages, setup  # type: ignore
 
 long_description = Path("README.md").read_text(encoding="utf-8")
 version = "0.2.2"
-package_name = "hi-ml-multimodal"
+package_name = "hi_ml_multimodal"
 install_requires = Path("requirements_run.txt").read_text().splitlines()
 
 description = "Microsoft Health Futures package to work with multi-modal health data"

--- a/hi-ml/setup.py
+++ b/hi-ml/setup.py
@@ -52,7 +52,8 @@ if not version:
         default_random_version_number = floor(random() * 10_000_000_000)
         version = f"0.1.0.post{str(default_random_version_number)}"
 
-(here / "package_name.txt").write_text("hi-ml")
+package_name = "hi_ml"
+(here / "package_name.txt").write_text(package_name)
 (here / "latest_version.txt").write_text(version)
 
 # Read run_requirements.txt to get install_requires
@@ -63,7 +64,7 @@ install_requires = [line.strip() for line in install_requires if line.strip()]
 description = "Microsoft Health Futures package containing high level ML components"
 
 setup(
-    name="hi-ml",
+    name=package_name,
     version=version,
     description=description,
     long_description=long_description,


### PR DESCRIPTION
PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. The filename must contain the normalized project name with underscores, so it's `hi_ml_azure` instead of `hi-ml-azure`